### PR TITLE
Allow selection of nearby stacks (fix #1)

### DIFF
--- a/website/wwt.css
+++ b/website/wwt.css
@@ -187,7 +187,23 @@ div#sourceinfo {
   max-width: 700px;
 }
 
-div#stackinfo div.main , div#sourceinfo div.main {
+/* based on #stackinfo/#sourceinfo */
+/* Would like this centered, but bottom-left is okay to start with */
+div#nearestinfo {
+  background: rgba(255, 255, 255, 0.6);
+  border: 2px solid white;
+  bottom: 0.5em;
+  cursor: move;
+  display: none;
+  left: 0.5em;
+  overflow: auto;  /* scroll bar looks ugly when shown */
+  padding: 0;
+  position: absolute;
+  z-index: 200;
+}
+
+div#stackinfo div.main , div#sourceinfo div.main ,
+div#nearestinfo div.main {
   background: rgba(255, 255, 255, 1);
 }
 
@@ -273,7 +289,7 @@ img.close {
 
 #preselected > img.close , #stackinfo > img.close ,
 #settings > img.close , #sourceinfo > img.close ,
-#plot > img.close {
+#nearestinfo > img.close , #plot > img.close {
   margin-right: 0.4em;
   margin-top: 0.4em;
 }

--- a/website/wwt.js
+++ b/website/wwt.js
@@ -514,7 +514,7 @@ var wwt = (function () {
     let edgeColor;
     let fillColor = 'white';
     let lineWidth;
-    const opacity = 0.1;
+    const opacity = 0.6;
     const fillFlag = false;
 
     if (stack.status) {
@@ -1774,7 +1774,48 @@ var wwt = (function () {
     return store;
   }
 
+  // For use when changing a stack annotation; returns an item
+  // that can be used to restore the fov.
+  //
+  // selected indicates that this is the "selected" stack
+  // rather than a "nearby" one.
+  //
+  function changeFov(fov, selected, lineColor, lineWidth) {
+    const old = {fov: fov, selected: selected,
+		 lineColor: fov.get_lineColor(),
+		 lineWidth: fov.get_lineWidth()};
+    fov.set_lineColor(lineColor);
+    fov.set_lineWidth(lineWidth);
+    return old;
+  }
+
+  // Use the output of changeFov to restore the annotation.
+  //
+  function resetFov(old) {
+    const fov = old.fov;
+    fov.set_lineColor(old.lineColor);
+    fov.set_lineWidth(old.lineWidth);
+  }
+
+  // Show this stack using the "nearest stack" logic. The assumption is
+  // that by using the stack location we will select this stack. The only
+  // reason this wouldn't hold would be numerical errors, and the way the
+  // stacks are created should mean this won't happen.
+  //
+  function processStackSelectionByName(stackid) {
+    const smatches = inputStackData.stacks.filter(d => d.stackid === stackid);
+    if (smatches.length === 0) {
+      console.log("INTERNAL ERROR: unknown stackid=" + stackid);
+      return;
+    }
+
+    // Assume only one match
+    const stack = smatches[0];
+    processStackSelection(stack.pos[0], stack.pos[1]);
+  }
+
   // Show the nearest stack: ra and dec are in degrees
+  //
   function processStackSelection(sra0, sdec0) {
 
     clearNearestStack();
@@ -1790,21 +1831,181 @@ var wwt = (function () {
       return;
     }
 
-    // Only interested in the closest stack
+    // Remove the closest item so we don't accidentally get confused later
+    // on (when dealing with small separations/numerical issues).
     //
-    const stack = seps[0][1];
-    const fovs = stackAnnotations[stack.stackid];
-    fovs.forEach(fov => {
-      const oldFov = [fov,
-                      fov.get_lineColor(),
-                      fov.get_lineWidth()];
+    const el0 = seps.shift();
+    const stack0 = el0[1];
 
-      fov.set_lineColor('cyan');
-      fov.set_lineWidth(4);
-      nearestFovs.push(oldFov);
+    const fovs = stackAnnotations[stack0.stackid];
+    fovs.forEach(fov => nearestFovs.push(changeFov(fov, true, 'cyan', 4)));
+
+    wwtprops.addStackInfo(stack0, stackEventVersions);
+
+    if (seps.length === 0) { return; }
+
+    // Apply a tolerance to identify if we have "close" stacks. This
+    // is a heuristic. Note that we are actually interested in stacks
+    // close to each other, so we repeart the nearest search but
+    // this time use the location of the nearest stack.
+    //
+    // Pick a tolerance based on ACIS chip size as a start, and then
+    // tweak. Ideally would know which FOVs overlapped, since this
+    // could be used, but that seems a bit excessive.
+    //
+    const tol = 12 / 60.0;
+    const nearest = findNearestTo(stack0.pos[0], stack0.pos[1], tol, seps,
+				  d => { return {ra: d[1].pos[0], dec: d[1].pos[1]}; },
+				  d => d[1]);
+
+    // Update the closest ensembles by drawing them in a different color.
+    //
+    nearest.forEach(d => {
+      const stack = d[1];
+      stackAnnotations[stack.stackid].forEach(fov => {
+	nearestFovs.push(changeFov(fov, false, 'cyan', 2));
+      });
     });
 
-    wwtprops.addStackInfo(stack, stackEventVersions);
+    displayNearestStackTable(stack0, nearest);
+  }
+
+  function hideNearestStackTable() {
+    const host = getHost();
+    if (host === null) { return; }
+
+    const pane = host.querySelector('#nearestinfo');
+    if (pane === null) {
+      console.log('INTERNAL ERROR: no #nearestinfo');
+      return;
+    }
+
+    pane.style.display = 'none';
+    removeChildren(pane);
+  }
+
+  // copied from wwtprops for now
+  function mkImg(alt, src, width, height, className) {
+    const img = document.createElement('img');
+    img.setAttribute('alt', alt);
+    img.setAttribute('width', width);
+    img.setAttribute('height', height);
+    img.setAttribute('src', src);
+    img.setAttribute('class', className);
+    return img;
+  }
+
+  // This is an experiment to see if we can make it easy to select
+  // stacks in crowded areas.
+  //
+  // Display a simple table with the stacks.
+  //
+  function displayNearestStackTable(stack0, neighbors) {
+    const n = neighbors.length;
+    if (n === 0) { return; }
+
+    const host = getHost();
+    if (host === null) { return; }
+
+    const pane = host.querySelector('#nearestinfo');
+    if (pane === null) {
+      console.log('INTERNAL ERROR: no #nearestinfo');
+      return;
+    }
+
+    const name = document.createElement('div');
+    name.setAttribute('class', 'name');
+    name.innerHTML = 'Nearest stack' + (n > 1 ? 's' : '');
+    pane.appendChild(name);
+
+    const imgClose = mkImg('Close', 'wwtimg/glyphicons-208-remove.png',
+			   18, 18, 'close');
+    imgClose.addEventListener('click', () => {
+      hideNearestStackTable()
+
+      // clear out the "nearest" stack outline; the easiest way is
+      // to just change them but do not change the nearestFovs array,
+      // since this will get done in a later call
+      nearestFovs.forEach(fov => {
+	if (fov.selected) { return; }
+	resetFov(fov);
+      });
+
+    });
+    pane.appendChild(imgClose);
+
+    const main = document.createElement('div');
+    main.setAttribute('class', 'main');
+    pane.appendChild(main);
+
+    const tbl = document.createElement('table');
+    main.appendChild(tbl);
+
+    const mkElem = (name, value) => {
+      const el = document.createElement(name);
+      el.innerHTML = value;
+      return el;
+    };
+
+    const thead = document.createElement('thead');
+    tbl.appendChild(thead);
+
+    let trow = document.createElement('tr');
+    thead.appendChild(trow);
+    trow.appendChild(mkElem('th', 'Stack'));
+    trow.appendChild(mkElem('th', 'Separation'));
+
+    const tbody = document.createElement('tbody');
+    tbl.appendChild(tbody);
+
+    const mkStack = (stkid) => {
+      const fovs = stackAnnotations[stkid];
+
+      const lnk = document.createElement('a');
+      lnk.setAttribute('href', '#');
+      lnk.appendChild(document.createTextNode(stkid));
+
+      // The mouseleave event will not fire if a user clicks on a link,
+      // so ensure we clean up.
+      //
+      lnk.addEventListener('click', () => {
+	fovs.forEach(fov => fov.set_fill(false));
+	processStackSelectionByName(stkid);
+      });
+
+      lnk.addEventListener('mouseenter', () => {
+	fovs.forEach(fov => fov.set_fill(true));
+      });
+
+      lnk.addEventListener('mouseleave', () => {
+	fovs.forEach(fov => fov.set_fill(false));
+      });
+
+      const td = document.createElement('td');
+      td.appendChild(lnk);
+      return td;
+    }
+
+    /*
+     * It's not obvious that showing the selected source is helpful
+    let trow = document.createElement('tr');
+    tbody.appendChild(trow);
+    trow.appendChild(mkStack(stack0.stackid));
+    trow.appendChild(mkElem('td', '0.0'));
+    */
+
+    neighbors.forEach(d => {
+      const sep = d[0];
+      const stack = d[1];
+      const trow = document.createElement('tr');
+      tbody.appendChild(trow);
+
+      const stackSep = (sep * 60.0).toFixed(1);
+      trow.appendChild(mkStack(stack.stackid));
+      trow.appendChild(mkElem('td', stackSep));
+    });
+
+    pane.style.display = 'block';
 
   }
 
@@ -1936,7 +2137,10 @@ var wwt = (function () {
     host.addEventListener('drop', draggable.stopDrag);
 
     const panes = ['#stackinfo', '#sourceinfo', '#preselected',
-		   '#settings', '#plot'];
+		   '#settings', '#plot'
+		   // , '#nearestinfo'  for now not draggable
+		   // as need to sort out window size properly
+		  ];
     panes.forEach((n) => {
       const pane = host.querySelector(n);
       if (pane !== null) {
@@ -2137,17 +2341,13 @@ var wwt = (function () {
   }
 
   function clearNearestStack() {
-
-    nearestFovs.forEach((fov) => {
-      fov[0].set_lineColor(fov[1]);
-      fov[0].set_lineWidth(fov[2]);
-    });
+    nearestFovs.forEach(fov => resetFov(fov));
     nearestFovs = [];
     wwtprops.clearStackInfo();
+    hideNearestStackTable();
   }
 
   function clearNearestSource() {
-
     if (nearestSource.length < 1) { return; }
 
     const src = nearestSource[0];

--- a/website/wwt.xml
+++ b/website/wwt.xml
@@ -368,6 +368,10 @@ main#content div.wrap {
 
       <div id="sourceinfo">
       </div>
+
+      <!-- used to identify "nearby" objects; an experiment -->
+      <div id="nearestinfo">
+      </div>
       
       <!-- Inform the user when the stack status has been updated -->
       <div id="stackUpdateStatus"></div>


### PR DESCRIPTION
Refactor the various pieces of code which were finding the closest "item" on the sky to a given position.

Use this refactoring to support identifying nearby stacks - not just the nearest - using a maximum radius of 12 arcminutes (a heuristic based on the ACIS chip size and then modified based on testing).

Display nearby stacks in a separate table: this table can be used to highlight each stack and then select it.