### PR TITLE
Remove glyphicons img as close-pane; add hide/show pane

### DIFF
--- a/website/js/wwtprops.js
+++ b/website/js/wwtprops.js
@@ -238,51 +238,70 @@ const wwtprops = (function () {
     return div;
   }
 
+  // Sent the div for the main contents and the title sections
+  //
+  function addHideShowButton(parent, titleBar) {
+    const el = document.createElement('span');
+    el.classList.add('switchable');
+    el.classList.add('hideable');
+    el.addEventListener('click', () => {
+      if (el.classList.contains('hideable')) {
+	parent.style.display = 'none';
+	el.classList.remove('hideable');
+	el.classList.add('showable');
+	titleBar.classList.remove('controlElementsShown');
+      } else {
+	parent.style.display = 'block';
+	el.classList.remove('showable');
+	el.classList.add('hideable');
+	titleBar.classList.add('controlElementsShown');
+      }
+    });
+    return el;
+  }
+
+  // Add a button that closes the stack (this logic is handled by the
+  // close callback).
+  //
+  function addCloseButton(close) {
+    const el = document.createElement('span');
+    el.setAttribute('class', 'closable');
+    el.addEventListener('click', close);
+    return el;
+  }
+
   // Create a "pop-up" window with details on the given stack.
   //
   // TODO: can I give the number of sources IN THIS STACK?
   //       not really a good answer to this, as have number of
   //       detections, but not sources.
   //
-  /***
-
-      No longer display the "completion" date of a stack so
-      do not need these.
-
-      const dayName = ['Sunday', 'Monday', 'Tuesday', 'Wednesday',
-      'Thursday', 'Friday', 'Saturday'];
-      const monthName = ['January', 'February', 'March', 'April',
-      'May', 'June', 'July', 'August', 'September',
-      'October', 'November', 'December'];
-  ***/
 
   function addStackInfo(stack, stackEventVersions) {
 
     const bcol = stack.status ? 'gold' : 'grey';
-
-    /***
-	TODO: want to make bcol the same as the stack was, before it
-	got changed to cyan. So can't ask the stack structure, unless
-	we manually store it there as the "default" color
-    ***/
-
     const parent = document.querySelector('#stackinfo');
     if (parent === null) {
       console.log('Internal error: no #stackinfo found');
       return;
     }
 
-    const nameDiv = mkDiv('name');
-    addText(nameDiv, 'Stack: ' + stack.stackid);
-    parent.appendChild(nameDiv);
+    const controlElements = document.createElement('div');
+    controlElements.classList.add('controlElements');
+    controlElements.classList.add('controlElementsShown');
 
-    const imgClose = mkImg('Close', 'wwtimg/glyphicons-208-remove.png',
-			   18, 18, 'close');
-    imgClose.id = 'closestackinfo';
-    imgClose.addEventListener('click', () => wwt.clearNearestStack());
-    parent.appendChild(imgClose);
+    parent.appendChild(controlElements);
+
+    const name = document.createElement('span');
+    name.setAttribute('class', 'title');
+    addText(name, 'Stack: ' + stack.stackid);
+    controlElements.appendChild(name);
 
     const mainDiv = mkDiv('main');
+
+    controlElements.appendChild(addCloseButton(wwt.clearNearestStack));
+    controlElements.appendChild(addHideShowButton(mainDiv, controlElements));
+
     parent.appendChild(mainDiv);
 
     const binfoDiv = mkDiv('basicinfo');
@@ -696,17 +715,22 @@ const wwtprops = (function () {
       return;
     }
 
-    const nameDiv = mkDiv('name');
-    addText(nameDiv, 'Source: ' + src.name);
-    parent.appendChild(nameDiv);
+    const controlElements = document.createElement('div');
+    controlElements.classList.add('controlElements');
+    controlElements.classList.add('controlElementsShown');
 
-    const imgClose = mkImg('Close', 'wwtimg/glyphicons-208-remove.png',
-			   18, 18, 'close');
-    imgClose.id = 'closesourceinfo';
-    imgClose.addEventListener('click', () => wwt.clearNearestSource());
-    parent.appendChild(imgClose);
+    parent.appendChild(controlElements);
+
+    const name = document.createElement('span');
+    name.setAttribute('class', 'title');
+    addText(name, 'Source: ' + src.name);
+    controlElements.appendChild(name);
 
     const mainDiv = mkDiv('main');
+
+    controlElements.appendChild(addCloseButton(wwt.clearNearestSource));
+    controlElements.appendChild(addHideShowButton(mainDiv, controlElements));
+
     parent.appendChild(mainDiv);
 
     const binfoDiv = mkDiv('basicinfo');
@@ -775,6 +799,18 @@ const wwtprops = (function () {
     wwt.removeToolTipHandler('export-samp-source');
   }
 
+  // Convert a separation in degrees to a "nice" string.
+  // Assume that the separation is <~ 20 arcminutes or so.
+  //
+  function mkSep(sep) {
+    const asep = sep * 60.0;
+    if (asep >= 1.0) {
+      return asep.toFixed(1) + "'";
+    } else {
+      return (asep * 60.0).toFixed(1) + '"';
+    }
+  }
+
   function addNearestStackTable(stackAnnotations, stack0, neighbors,
 				nearestFovs) {
     const n = neighbors.length;
@@ -786,14 +822,21 @@ const wwtprops = (function () {
       return;
     }
 
-    const name = mkDiv('name');
-    name.innerHTML = 'Nearest stack' + (n > 1 ? 's' : '');
-    pane.appendChild(name);
+    const controlElements = document.createElement('div');
+    controlElements.classList.add('controlElements');
+    controlElements.classList.add('controlElementsShown');
 
-    const imgClose = mkImg('Close', 'wwtimg/glyphicons-208-remove.png',
-			   18, 18, 'close');
-    imgClose.addEventListener('click', () => {
-      clearNearestStackTable()
+    pane.appendChild(controlElements);
+
+    const name = document.createElement('span');
+    name.setAttribute('class', 'title');
+    name.innerHTML = 'Nearest stack' + (n > 1 ? 's' : '');
+    controlElements.appendChild(name);
+
+    const main = mkDiv('main');
+
+    const close = () => {
+      clearNearestStackTable();
 
       // clear out the "nearest" stack outline; the easiest way is
       // to just change them but do not change the nearestFovs array,
@@ -803,10 +846,10 @@ const wwtprops = (function () {
 	fov.reset();
       });
 
-    });
-    pane.appendChild(imgClose);
+    };
+    controlElements.appendChild(addCloseButton(close));
+    controlElements.appendChild(addHideShowButton(main, controlElements));
 
-    const main = mkDiv('main');
     pane.appendChild(main);
 
     const tbl = document.createElement('table');
@@ -873,9 +916,8 @@ const wwtprops = (function () {
 	trow.classList.remove('selected');
       });
 
-      const stackSep = (sep * 60.0).toFixed(1);
       trow.appendChild(mkStack(stack.stackid, fovs));
-      trow.appendChild(mkElem('td', stackSep));
+      trow.appendChild(mkElem('td', mkSep(sep)));
     });
 
     pane.style.display = 'block';
@@ -892,13 +934,20 @@ const wwtprops = (function () {
       return;
     }
 
-    const name = mkDiv('name');
-    name.innerHTML = 'Nearest source' + (n > 1 ? 's' : '');
-    pane.appendChild(name);
+    const controlElements = document.createElement('div');
+    controlElements.classList.add('controlElements');
+    controlElements.classList.add('controlElementsShown');
 
-    const imgClose = mkImg('Close', 'wwtimg/glyphicons-208-remove.png',
-			   18, 18, 'close');
-    imgClose.addEventListener('click', () => {
+    pane.appendChild(controlElements);
+
+    const name = document.createElement('span');
+    name.setAttribute('class', 'title');
+    name.innerHTML = 'Nearest source' + (n > 1 ? 's' : '');
+    controlElements.appendChild(name);
+
+    const main = mkDiv('main');
+
+    const close = () => {
       clearNearestSourceTable()
 
       // Are we going to be highlighting the nearby sources in any way?
@@ -909,10 +958,10 @@ const wwtprops = (function () {
 	fov.reset();
       });
       ***/
-    });
-    pane.appendChild(imgClose);
+    };
+    controlElements.appendChild(addCloseButton(close));
+    controlElements.appendChild(addHideShowButton(main, controlElements));
 
-    const main = mkDiv('main');
     pane.appendChild(main);
 
     const tbl = document.createElement('table');
@@ -1011,9 +1060,8 @@ const wwtprops = (function () {
 	trow.classList.remove('selected');
       });
 
-      const srcSep = (sep * 60.0).toFixed(1);
       trow.appendChild(mkSrcLink(src, pos.ra, pos.dec, ann, origColor));
-      trow.appendChild(mkElem('td', srcSep));
+      trow.appendChild(mkElem('td', mkSep(sep)));
       trow.appendChild(mkElem('td', src[sigIdx]));
 
       trow.appendChild(mkButton(src[varIdx]));

--- a/website/wwt.css
+++ b/website/wwt.css
@@ -295,6 +295,82 @@ img.close {
   margin-top: 0.4em;
 }
 
+/* location of window-UI-like elements */
+
+div.controlElements {
+
+    height: 1em;
+
+    /* The control box extends across the full pane.
+     * Do we need to 'undo' any padding from a parent element? */
+    /***
+    margin-left: -0.5em;
+    margin-right: -0.5em;
+ ***/
+    
+    padding-bottom: 0.3em;
+    padding-right: 0.3em;
+    padding-top: 0.3em;
+}
+
+/* do we want a border when the whole pane is displayed? */
+div.controlElementsShown {
+    /* border-bottom: 2px solid rgba(0, 0, 0, 0.4); */
+}
+
+span.title {
+  background: rgba(255, 255, 255, 0.6);
+  /* float: left; */
+  /* margin-bottom: 0; */
+  margin-left: 0.5em;
+  margin-right: 0.5em;
+  /* margin-top: 0.3em; */
+  padding-bottom: 0.2em;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+  padding-top: 0.2em;
+}
+
+/* CSS window "widgets" */
+
+.closable {
+    background: black;
+    border-radius: 50%;
+    cursor: pointer;
+    float: right;
+    height: 1em;
+    width: 1em;
+}
+
+/* need to add extra vertical space in several cases */
+#about .closable , #credits .closable {
+  margin-top: 1em;
+}
+
+/* hideable and showable are assumed to be attached to this */
+.switchable {
+    cursor: pointer;
+    float: right;
+    height: 0;
+    margin-left: 0.5em;
+    margin-right: 0.2em;
+    width: 0;
+}
+
+/* down-pointing triangle */
+.hideable {
+    border-left: 0.5em solid transparent;
+    border-right: 0.5em solid transparent;
+    border-top: 1em solid black;
+}
+
+/* up-pointing triangle */
+.showable {
+    border-bottom: 1em solid black;
+    border-left: 0.5em solid transparent;
+    border-right: 0.5em solid transparent;
+}
+
 
 tr.selected {
   background: rgba(0, 0, 0, 0.1);
@@ -871,7 +947,8 @@ div.mainbar + br {
   z-index: 250;
 }
 
-#plotarea {
+/* not sure how many of these settings are still needed */
+div#plot #main {
   background: rgba(255, 255, 255, 1.0);
   clear: both;
   padding: 0.5em 1em;

--- a/website/wwt.js
+++ b/website/wwt.js
@@ -2132,6 +2132,48 @@ var wwt = (function () {
 
   }
 
+  // Set up the onclick handler for the given "pane". This should check
+  // that the handler hasn't already been added.
+  //
+  function setupShowHide(sel) {
+    const pane = document.querySelector(sel);
+    if (pane === null) {
+      console.log('INTERNAL ERROR: unable to find ' + sel);
+      return;
+    }
+
+    const find = lbl => {
+      const el = pane.querySelector(lbl);
+      if (el === null) {
+	console.log(`INTERNAL ERROR: umable to find ${lbl} in ${sel}`);
+      }
+      return el;
+    };
+
+    // Assume we can take the first one, since we have not given the
+    // element an id.
+    const control = find('div.controlElements');
+    const main = find('div.main');
+    const el = find('span.switchable');
+    if ((control === null) || (main === null) || (el === null)) {
+      return;
+    }
+
+    el.addEventListener('click', () => {
+      if (el.classList.contains('hideable')) {
+	main.style.display = 'none';
+	el.classList.remove('hideable');
+	el.classList.add('showable');
+	control.classList.remove('controlElementsShown');
+      } else {
+	main.style.display = 'block';
+	el.classList.remove('showable');
+	el.classList.add('hideable');
+	control.classList.add('controlElementsShown');
+      }
+    });
+  }
+
   // This used to be sent in data, hence the function returning a function,
   // but that should no-longer be needed.
   //
@@ -2184,6 +2226,10 @@ var wwt = (function () {
       removeSetupBanner();
 
       wwtsamp.setup(reportUpdateMessage, trace);
+
+      setupShowHide('#preselected');
+      setupShowHide('#settings');
+      setupShowHide('#plot');
 
       // Display the control panel
       //

--- a/website/wwt.js
+++ b/website/wwt.js
@@ -2227,7 +2227,9 @@ var wwt = (function () {
 
       wwtsamp.setup(reportUpdateMessage, trace);
 
-      setupShowHide('#preselected');
+      // The pane width is lost when re-selected which messes up the
+      // grid in the preselected pane.
+      // setupShowHide('#preselected');
       setupShowHide('#settings');
       setupShowHide('#plot');
 

--- a/website/wwt.xml
+++ b/website/wwt.xml
@@ -387,16 +387,8 @@ main#content div.wrap {
 
       <!-- <div class="pane" id="welcome"> -->
       <div id="welcome">
-	<!--
-        <button type="button" class="close"
-                onclick="wwt.hideElement('welcome');">
-	  <img src="wwtimg/glyphicons-208-remove.png" width="18" height="18"
-	       alt="Close"/>
-	</button>
-	-->
-	<img class="close" onclick="wwt.hideElement('welcome');"
-	     src="wwtimg/glyphicons-208-remove.png" width="18" height="18"
-	     alt="Close"/>
+	<span class="closable" onclick="wwt.hideElement('welcome');">
+	</span>
 
         <h2>Please explore the Chandra Source Catalog</h2>
 	<p>
@@ -453,13 +445,8 @@ main#content div.wrap {
       </div>
       
       <div class="pane" id="about">
-	<!--
-        <button type="button" class="close"
-                onclick="wwt.hideElement('about');">X</button>
-	-->
-	<img class="close" onclick="wwt.hideElement('about');"
-	     src="wwtimg/glyphicons-208-remove.png" width="18" height="18"
-	     alt="Close"/>
+	<span class="closable" onclick="wwt.hideElement('about');">
+	</span>
 
         <h2>About this page</h2>
         
@@ -751,10 +738,13 @@ main#content div.wrap {
       </div>
 
       <div id="settings">
-        <div class="name">Settings:</div>
-	<img class="close" onclick="wwt.hideSettings();"
-	     src="wwtimg/glyphicons-208-remove.png" width="18" height="18"
-	     alt="Close"/>
+	<div class="controlElements controlElementsShown">
+          <span class="title">Settings:</span>
+	  <span class="closable" onclick="wwt.hideSettings();">
+	  </span>
+	  <span class="switchable hideable">
+	  </span>
+	</div>
 
 	<div class="main">
 	  <p>
@@ -817,15 +807,14 @@ main#content div.wrap {
       </div> <!-- #settings -->
 
       <div id="preselected">
-        <div class="name">Move to:</div>
 
-	<!--
-        <button type="button" class="close"
-                onclick="wwt.hidePreSelected();">X</button>
-	-->
-	<img class="close" onclick="wwt.hidePreSelected();"
-	     src="wwtimg/glyphicons-208-remove.png" width="18" height="18"
-	     alt="Close"/>
+	<div class="controlElements controlElementsShown">
+          <span class="title">Move to:</span>
+	  <span class="closable" onclick="wwt.hidePreSelected();">
+	  </span>
+	  <span class="switchable hideable">
+	  </span>
+	</div>
 
         <div class="main gridable">
           <input type="button" id="m31" value="Andromeda"
@@ -885,13 +874,9 @@ main#content div.wrap {
       </div>
 
       <div class="pane" id="credits">
-	<!--
-        <button type="button" class="close"
-                onclick="wwt.hideElement('credits');">X</button>
-	-->
-	<img class="close" onclick="wwt.hideElement('credits');"
-	     src="wwtimg/glyphicons-208-remove.png" width="18" height="18"
-	     alt="Close"/>
+
+	<span class="closable" onclick="wwt.hideElement('credits');">
+	</span>
 
         <h2>Credits</h2>
         <p>
@@ -913,7 +898,7 @@ main#content div.wrap {
           <extlink href="http://www.skymap.com/milkyway_cat.htm">Milky Way
             Outline Catalogs data</extlink>
           by Jose R. Vieira.
-          The configuration, close, plot, resize, reshare, search, and zoom
+          The configuration, plot, resize, reshare, search, and zoom
 	  icons are from the
 	  free version of the
           <extlink href="http://glyphicons.com/">GLYPHICONS.com</extlink>
@@ -1079,17 +1064,15 @@ main#content div.wrap {
 
       <!-- plot areas -->
       <div id="plot">
-	<div class='name'>Overview of the selected CSC 2.0 sources</div>
+	<div class="controlElements controlElementsShown">
+          <span class="title">Overview of the selected CSC 2.0 sources</span>
+	  <span class="closable" onclick="wwt.hideElement('plot');">
+	  </span>
+	  <span class="switchable hideable">
+	  </span>
+	</div>
 
-	<!--
-	    <button type="button" class="close"
-            onclick="wwt.hideElement('plot');">X</button>
-	-->
-	<img class="close" onclick="wwt.hideElement('plot');"
-	     src="wwtimg/glyphicons-208-remove.png" width="18" height="18"
-	     alt="Close"/>
-	  
-	<div id="plotarea">
+	<div class="main">
 	  <p>
 	    Note that no error ranges are included in these visualizations.
 	    For a more-detailed analysis try sending

--- a/website/wwt.xml
+++ b/website/wwt.xml
@@ -812,8 +812,10 @@ main#content div.wrap {
           <span class="title">Move to:</span>
 	  <span class="closable" onclick="wwt.hidePreSelected();">
 	  </span>
+	  <!-- does not work well at the moment when re-displaying the pane
 	  <span class="switchable hideable">
 	  </span>
+	  -->
 	</div>
 
         <div class="main gridable">


### PR DESCRIPTION
When I downloaded the glyphicons they were freely available. They have now been re-licensed, so I am moving away from using them. This PR replaces the close icon (a black cross) with a black circle drawn with CSS. It also adds hide/show triangles to most panes.