### PR TITLE
Lazy creation of sources (CSC 2.0, 1.1, and XMM) fix #5

### DIFF
--- a/website/js/wwtprops.js
+++ b/website/js/wwtprops.js
@@ -923,8 +923,7 @@ const wwtprops = (function () {
     pane.style.display = 'block';
   }
 
-  function addNearestSourceTable(catalogData, indexes, annotations,
-				 neighbors) {
+  function addNearestSourceTable(indexes, neighbors) {
     const n = neighbors.length;
     if (n === 0) { return; }
 
@@ -996,10 +995,6 @@ const wwtprops = (function () {
     const bandIdx = indexes.fluxband;
     const fluxIdx = indexes.flux;
 
-    const addText = (parent, text) => {
-      parent.appendChild(document.createTextNode(text));
-    };
-
     const mkSrcLink = (src, ra, dec, ann, origColor) => {
       const name = src[nameIdx];
       const lnk = document.createElement('a');
@@ -1040,11 +1035,11 @@ const wwtprops = (function () {
 
     neighbors.forEach(d => {
       const sep = d[0];
-      const idx = d[1].id;
-      const pos = d[1].pos;
-      const src = catalogData[idx];
+      const src = d[1].data;
+      const ra = d[1].ra;
+      const dec = d[1].dec;
+      const ann = d[1].ann;
 
-      const ann = annotations[idx][2];
       const origColor = ann.get_lineColor();
 
       const trow = document.createElement('tr');
@@ -1060,7 +1055,7 @@ const wwtprops = (function () {
 	trow.classList.remove('selected');
       });
 
-      trow.appendChild(mkSrcLink(src, pos.ra, pos.dec, ann, origColor));
+      trow.appendChild(mkSrcLink(src, ra, dec, ann, origColor));
       trow.appendChild(mkElem('td', mkSep(sep)));
       trow.appendChild(mkElem('td', src[sigIdx]));
 


### PR DESCRIPTION
Rather than create the WWT annotation objects for all sources when the
data has been loaded, this now creates them on the fly (when a user says
"show sources in this area").

This reduces the "download" time at the expense of increased run time each
time a "show sources" command is issued. However, it is likely that the
latter is imperceptible (apart from the most extreme cases).

It also has the advantage of making the color/size changing more responsive,
since a much-smaller number of annotations have to be changed.

This should reduce memory usage (not tested).

It also paves the way to reading these catalogs "on demand" (in a similar
manner to ESA sky) rather than "all in one", if we so desire to go in
this direction.