### PR TITLE
Add the code to extract stack version numbers

### DIFF
--- a/code/get_evtnames.py
+++ b/code/get_evtnames.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+"""
+Usage:
+
+  python get_evtnames.py infile
+
+Aim:
+
+Query csccli to return the "name" of the stack event files - that
+is, the file name needed to query the csccli to get the data product.
+
+infile must have a stack column
+
+"""
+
+import sys
+
+from six.moves import urllib
+
+import json
+
+
+def report_evtname(stack):
+
+    url = 'http://cda.harvard.edu/csccli/browse?version=cur&packageset={}%2Fstkevt3'.format(stack)
+
+    try:
+        resp = urllib.request.urlopen(url).read()
+    except urllib.error.URLError as ue:
+        sys.stderr.write("ERROR: url={} error={}\n".format(url, ue))
+        # sys.exit(1)
+        return
+
+    # oh, let's be all python3-ey
+    cts = json.loads(resp.decode('utf8'))
+    if len(cts) != 1:
+        sys.stderr.write("ERROR: stack={} returned {}\n".format(stack, cts))
+        return
+
+    try:
+        filename = cts[0]['filename']
+    except KeyError:
+        sys.stderr.write("Error: stack={} no filename in {}\n".format(stack, cts))
+        return
+
+    print("{} {}".format(stack, filename))
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+
+    if len(sys.argv) != 2:
+        sys.stderr.write("Usage: {} stacks\n".format(sys.argv[0]))
+        sys.exit(1)
+
+    infile = sys.argv[1] + "[cols stack]"
+
+    import pycrates
+    cr = pycrates.read_file(infile)
+    if cr.get_nrows() == 0:
+        raise IOError("No stacks in {}".format(infile))
+
+    print("# stack filename")
+    for stk in cr.get_column('stack').values:
+        report_evtname(stk)

--- a/code/parse_evtnames.py
+++ b/code/parse_evtnames.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python -w
+
+"""
+Usage:
+
+  ./parse_evtnames.py output-of-get_evtnames.py [default-version]
+
+Aim:
+
+Construct a JSON file mapping from stack id to version number. The
+default value is taken to be 20, unless explicitly listed. This is
+used
+
+a) to save space
+b) to handle cases where we are missing the mapping data
+   (under the assumption that 20 is still valid)
+
+"""
+
+import sys
+
+from collections import OrderedDict
+
+import json
+
+
+def convert(infile, default_version, filetype='stkevt3'):
+
+    # Force an ordering to avoid un-needed reloads (by web browser)
+    out = OrderedDict()
+    out['filetype'] = filetype
+    out['versions'] = OrderedDict()
+
+    # Parse into the full structure, and only later handle the
+    # default version
+    #
+    ndef = 0
+    with open(infile, 'r') as fh:
+        for l in fh.readlines():
+            l = l.strip()
+            if l == '' or l.startswith('#'):
+                continue
+
+            toks = l.split()
+            assert len(toks) == 2, l
+
+            stack = toks[0]
+            assert stack not in out['versions'], stack
+            filename = toks[1]
+
+            idx = filename.find('N')
+            assert idx > 0, filename
+
+            verstr = filename[idx + 1:idx + 4]
+            try:
+                ver = int(verstr)
+            except TypeError:
+                assert False, filename
+
+            # Is an integer smaller than a 3-character string - for
+            # our purposes it should be.
+            #
+            out['versions'][stack] = ver
+
+            if ver == default_version:
+                ndef += 1
+
+    if ndef == 0:
+        raise ValueError("No matches to default version={}".format(devault_version))
+
+    out['default_version'] = default_version
+    out['ndefault_version'] = ndef
+    delete = []
+    for stack, ver in out['versions'].items():
+        if ver == default_version:
+            delete.append(stack)
+
+    assert len(delete) == ndef
+    for stack in delete:
+        del out['versions'][stack]
+
+    print(json.dumps(out))
+
+
+def usage(progname):
+    sys.stderr.write("Usage: {} infile [default-value]\n".format(progname))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+
+    nargs = len(sys.argv)
+    if (nargs < 2) or (nargs > 3):
+        usage(sys.argv[0])
+
+    defver = 20
+    if nargs == 3:
+        defver = int(sys.argv[2])
+        if (defver < 1) or (defver > 999):
+            raise ValueError("Invalid defver={}".format(sys.argv[2]))
+
+    convert(sys.argv[1], defver)

--- a/website/js/wwtprops.js
+++ b/website/js/wwtprops.js
@@ -532,12 +532,19 @@ const wwtprops = (function () {
     }
 
     let stackVersion = null;
-    if ((stackEventVersions !== null) &&
-	(stack.stackid in stackEventVersions.versions)) {
-      stackVersion = stackEventVersions.versions[stack.stackid];
-    } else {
-      console.log('WARNING: No version found for stack=[' +
-		  stack.stackid + ']');
+    if (stackEventVersions !== null) {
+      if (stack.stackid in stackEventVersions.versions) {
+	stackVersion = stackEventVersions.versions[stack.stackid];
+      } else {
+	stackVersion = stackEventVersions.default_version;
+      }
+      /* This should not happen, unless the code hasn't picked up the
+       * new JSON file, so there is no default_version field.
+       */
+      if (typeof stackVersion === 'undefined') {
+	console.log(`WARNING: stackVersion is undefined for ${stack.stackid}`);
+	stackVersion = null;
+      }
     }
 
     addStackInfoContents(parent, stack, stackVersion, true);


### PR DESCRIPTION
This also uses a compressed format, by supporting a default value,
which also assumes the 26 stacks we currently can't (with the same
interface) get the version numbers for have this value (20).

This hopefully addresses the issue that lead to #8 