### PR TITLE
Replace the glyphicons search icon with CSS

### DIFF
--- a/website/wwt.css
+++ b/website/wwt.css
@@ -748,15 +748,48 @@ div.basicinfo + br {
 
 #targetName {
   margin-top: 0.4em;
-  width: 10em;
+  width: 14em;
 }
 
-#targetFind img {
-  float: right;
+/*
+ * replace image by CSS
+ * taken from https://css-tricks.com/the-shapes-of-css/
+ *
+ * do we need rules for when it is disabled?
+ */
+#targetFind {
+  font-size: 1.5em;
+  display: inline-block;
+  /* width: 0.4em; */
+  box-sizing: content-box;
+  height: 0.4em;
+  border: 0.1em solid rgba(0, 0, 0, 1);
+  position: relative;
+  border-radius: 0.35em;
+  background-color: rgba(255, 255, 255, 0.8);
 }
 
-#targetFind img {
-  height: 1em;
+#targetFind::before {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  right: -0.25em;
+  bottom: -0.1em;
+  border-width: 0;
+  background: rgba(0, 0, 0, 1);
+  width: 0.35em;
+  height: 0.08em;
+  transform: rotate(45deg);
+}
+
+#targetFind:disabled {
+  background-color: rgba(255, 255, 255, 0.5);
+  border-color: rgba(0, 0, 0, 0.5);
+}
+
+/* can I target the :before rule for when :disabled is added ? */
+#targetFind:disabled::before {
+  background: rgba(0, 0, 0, 0.5);
 }
 
 /* temporary information panes */

--- a/website/wwt.xml
+++ b/website/wwt.xml
@@ -202,7 +202,6 @@ main#content div.wrap {
 	  <button type="submit"
                   id="targetFind"
                   disabled="true">
-	    <img src="wwtimg/glyphicons-28-search.png" alt="Search"/>
 	  </button>
 	  <p class="tooltip" id="targetName-tooltip">
 	    A name can be given (e.g.
@@ -920,7 +919,7 @@ main#content div.wrap {
           <extlink href="http://www.skymap.com/milkyway_cat.htm">Milky Way
             Outline Catalogs data</extlink>
           by Jose R. Vieira.
-          The configuration, plot, resize, reshare, search, and zoom
+          The configuration, plot, resize, reshare, and zoom
 	  icons are from the
 	  free version of the
           <extlink href="http://glyphicons.com/">GLYPHICONS.com</extlink>


### PR DESCRIPTION
The CSS styling isn't consistent between browsers, so I should maybe
switch to font awesome, or some other source, for a search icon.