### PR TITLE
Explicit support for user actions

### DIFF
--- a/website/js/wwtprops.js
+++ b/website/js/wwtprops.js
@@ -1195,6 +1195,100 @@ const wwtprops = (function () {
     clearElement('#nearestsourceinfo');
   }
 
+  // What can we do for polygon source selection?
+  //
+  function addPolygonPane(host) {
+    let parent = host.querySelector('#polygoninfo');
+    if (parent === null) {
+      parent = mkDiv('polygoninfopane');
+      parent.id = 'polygoninfo';
+      host.appendChild(parent);
+    } else {
+      removeChildren(parent);
+    }
+
+    const controlElements = document.createElement('div');
+    controlElements.classList.add('controlElements');
+    controlElements.classList.add('controlElementsShown');
+
+    parent.appendChild(controlElements);
+
+    const name = document.createElement('span');
+    name.setAttribute('class', 'title');
+    addText(name, 'Source selection');
+    controlElements.appendChild(name);
+
+    const mainDiv = mkDiv('main');
+
+    const active = true;
+    controlElements.appendChild(addCloseButton(closePolygonPane, active));
+    controlElements.appendChild(addHideShowButton(mainDiv, controlElements, active));
+
+    parent.appendChild(mainDiv);
+
+    const pwarn = document.createElement('p');
+    addText(pwarn, '*** NOT FULLY FUNCTIONAL YET ***');
+    mainDiv.appendChild(pwarn);
+
+    const p = document.createElement('p');
+    addText(p, 'Add edges of a polygon by left-clicking.');
+    mainDiv.appendChild(p);
+
+    const pinfo = document.createElement('p');
+    pinfo.id = 'number-of-polygon-points';
+    addText(pinfo, 'No points selected!');
+    mainDiv.appendChild(pinfo);
+
+    const buttonDiv = mkDiv('button-container');
+    mainDiv.appendChild(buttonDiv);
+
+    const btn1 = document.createElement('button');
+    btn1.id = 'finished-polygon';
+    btn1.setAttribute('class', 'button');
+    btn1.setAttribute('type', 'button');
+    addText(btn1, 'End selection');
+    btn1.disabled = true;
+    btn1.addEventListener('click',
+			  () => alert('Not sure what to do yet'));
+    buttonDiv.appendChild(btn1);
+
+    const btn2 = document.createElement('button');
+    btn2.setAttribute('class', 'button');
+    btn2.setAttribute('type', 'button');
+    addText(btn2, 'Cancel');
+    btn2.addEventListener('click', closePolygonPane);
+    buttonDiv.appendChild(btn2);
+
+    parent.style.display = 'block';
+  }
+
+  // Note: this switches back to source selection; not 100% convinced
+  //       about this
+  function closePolygonPane() {
+    wwt.clearRegionSelection();
+
+    const el = document.querySelector('#polygoninfo');
+    if (el !== null) {
+      el.style.display = 'none';
+    }
+
+    const sel = document.querySelector('#selectionmode');
+    for (var idx = 0; idx < sel.options.length; idx++) {
+      const opt = sel.options[idx];
+      if (opt.value === 'source') {
+	opt.selected = true;
+      }
+    }
+
+    try {
+      sel.dispatchEvent(new CustomEvent('change'));
+    }
+    catch (e) {
+      console.log('INTERNAL ERROR: unable to change selection mode: ' + e);
+    }
+
+  }
+
   return { addStackInfo: addStackInfo,
 	   addStackInfoHelp: addStackInfoHelp,
 	   clearStackInfo: clearStackInfo,
@@ -1207,6 +1301,9 @@ const wwtprops = (function () {
 	   addNearestSourceTable: addNearestSourceTable,
 	   clearNearestStackTable: clearNearestStackTable,
 	   clearNearestSourceTable: clearNearestSourceTable,
+
+	   addPolygonPane: addPolygonPane,
+	   closePolygonPane: closePolygonPane,
 
 	   raToTokens: raToTokens,
 	   decToTokens: decToTokens,

--- a/website/wwt.css
+++ b/website/wwt.css
@@ -159,8 +159,14 @@ output#dec_d { width: 2em; }
 output#ra_s { width: 3.5em; }
 output#dec_s { width: 2.5em; }
 
-/* Should differentiate stack and source boxes */
-div.stackinfopane , div.sourceinfopane {
+/* Since the stack and source info boxes appear in the help area,
+ * do not apply all settings in this section, as some are left for
+ * div#xxxinfo or later rules. Examples include the cursor and
+ * position settings
+ */
+div.stackinfopane , div.sourceinfopane ,
+div.neareststackinfopane , div.nearestsourceinfopane ,
+div.polygoninfopane {
   background: rgba(255, 255, 255, 0.6);
   border: 2px solid white;
   padding: 0;
@@ -208,20 +214,28 @@ div.infocontainer {
 /* based on .stackinfopane/.sourceinfopane */
 /* Would like this centered, but bottom-left is okay to start with */
 div.neareststackinfopane , div.nearestsourceinfopane {
-  background: rgba(255, 255, 255, 0.6);
-  border: 2px solid white;
   bottom: 0.5em;
   cursor: move;
   display: none;
   left: 0.5em;
   overflow: auto;  /* scroll bar looks ugly when shown */
-  padding: 0;
+  position: absolute;
+  z-index: 200;
+}
+
+div.polygoninfopane {
+  bottom: 0.5em;
+  cursor: move;
+  display: none;
+  right: 0.5em;
+  overflow: auto;
   position: absolute;
   z-index: 200;
 }
 
 div.stackinfopane div.main , div.sourceinfopane div.main ,
-div.neareststackinfopane div.main , div.nearestsourceinfopane div.main {
+div.neareststackinfopane div.main , div.nearestsourceinfopane div.main ,
+div.polygoninfopane div.main {
   background: rgba(255, 255, 255, 1);
 }
 
@@ -305,6 +319,7 @@ img.close {
   margin-top: 0.5em;
 }
 
+/* TODO: review how many of these are still needed */
 .preselectedpane > img.close , .stackinfopane > img.close ,
 .settingspane > img.close , .sourceinfopane > img.close ,
 .neareststackinfopane > img.close , .nearestsourceinfopane > img.close ,

--- a/website/wwt.css
+++ b/website/wwt.css
@@ -108,7 +108,7 @@ div#WorldWideTelescopeControlHost {
 /* Since this is not a selectable element, use a different style to
  * the buttons
  */
-#numbers, #selectionmode {
+#numbers {
   background-color: rgba(153, 204, 102, 0.8); /* #99CC66 made transparent */
   border: 1px solid rgb(115, 172, 57); /* from http://www.colorhexa.com/99cc66 */
   color: rgba(0, 0, 0, 0.8);
@@ -118,7 +118,7 @@ div#WorldWideTelescopeControlHost {
   padding: 0.5em;
   text-align: center;
   vertical-align: middle;
-  width: 15.8em; /* this seems to make it the same width as explanation */
+  width: 15.8em; /* TODO: review this */
 }
 
 #location {
@@ -490,6 +490,13 @@ div.basicinfo + br {
   background-color: rgba(217, 83, 79, 0.4);  /* red-ish */
   border: 1px solid rgb(212, 63, 58);
   cursor: pointer;
+}
+
+/* handle disabled items in an input button; the default is
+ * graytext but this is hard to read */
+
+option:disabled {
+  color: rgba(0, 0, 0, 0.4);
 }
 
 .settingspane .button {

--- a/website/wwt.xml
+++ b/website/wwt.xml
@@ -194,8 +194,8 @@ main#content div.wrap {
 		onchange="wwt.setSelectionMode(event.target.value);">
 	  <option value="stack">Select nearest stack</option>
 	  <option value="source" disabled="true">Select nearest source</option>
-	  <option value="polygon" disabled="true">Select sources</option>
-	  <option value="nothing">Disable left click</option>
+	  <option value="polygon" disabled="true">Lasso sources</option>
+	  <option value="nothing">No selection</option>
 	</select>
 	<br/>
 

--- a/website/wwt.xml
+++ b/website/wwt.xml
@@ -189,9 +189,14 @@ main#content div.wrap {
 	  </p>
         </span>
         <br/>
-	<span id="selectionmode">
-	  Select nearest stack
-	</span>
+
+	<select id="selectionmode" name="selectionmode" class="button"
+		onchange="wwt.setSelectionMode(event.target.value);">
+	  <option value="stack">Select nearest stack</option>
+	  <option value="source" disabled="true">Select nearest source</option>
+	  <option value="polygon" disabled="true">Select sources</option>
+	  <option value="nothing">Disable left click</option>
+	</select>
 	<br/>
 
         <div id="userSelection" class="with-tooltip-static">
@@ -406,10 +411,10 @@ main#content div.wrap {
 	  observations included in the catalog - or, if the
 	  CSC 2.0 sources are displayed, then the properties of the
 	  nearest source will be shown
-	  (<span class="example-button">Load CSC 2.0 Sources</span>
+	  (<span class="example-button">Load CSC2.0 Sources</span>
 	  is used to load the data, after which it will turn
 	  into
-	  <span class="example-button">Show CSC 2.0 Sources</span>).
+	  <span class="example-button">Show CSC2.0 Sources</span>).
 	  A set of summary visualizations of the selected
 	  sources can be displayed with the
 	  <img alt="Plot source properties"
@@ -636,7 +641,7 @@ main#content div.wrap {
 	<h3>Selecting a source</h3>
 
 	<p>
-	  When the "Show CSC 2.0 Sources" button has been selected, the
+	  When the "Show CSC2.0 Sources" button has been selected, the
 	  selction mode - which is displayed in the second row of the
 	  menu bar on the left of the page - changes to
 	  "<span class="term">Select nearest source</span>" - and
@@ -699,7 +704,7 @@ main#content div.wrap {
 	<p>
 	  Since the data files can take some time to load, the
 	  source catalogs must be loaded - using the
-	  "<span class="term">Load CSC 2.0 Sources</span>"
+	  "<span class="term">Load CSC2.0 Sources</span>"
 	  or 
 	  "<span class="term">Load 3XMM-DR8 Sources</span>"
 	  buttons - before they can be shown. Once the data
@@ -708,14 +713,14 @@ main#content div.wrap {
 
 	<p>
 	  Selecting the
-	  "<span class="term">Show CSC 2.0 Sources</span>"
+	  "<span class="term">Show CSC2.0 Sources</span>"
 	  or 
 	  "<span class="term">Show 3XMM-DR8 Sources</span>"
 	  button will add circles, indicating the sources, close
 	  to the location on the screen (the full catalogs are
 	  <em>not</em> drawn as this would result in the display
 	  being unusable!). An orange circle is drawn to show the
-	  maximum radius used for sources (only for the CSC 2 sources).
+	  maximum radius used for sources (only for the CSC 2.0 sources).
 	</p>
 
 	<p>
@@ -725,7 +730,8 @@ main#content div.wrap {
 	  generally <em>significantly larger</em> than the positional
 	  error on the location; instead the values were chosen to
 	  make sure that the sources are visible!
-	  The Chandra locations are either from the CSC 2 catalog or -
+	  <!-- XXX TODO update the following sentence XXX -->
+	  The Chandra locations are either from the CSC 2.0 catalog or -
 	  for sources which have not been fully processed - from the
           <cxclink href="pre1/">November 2017 pre-release list</cxclink>.
 	  The values should therefore be taken as preliminary.


### PR DESCRIPTION
Let the user determine what a "left click" on the WWT means. This also adds support for a "lasso" operation, where a polygon can be drawn around the sources, but it doesn't let you do anything with the selection. It is therefore firmly in the "experimental" camp.