### PR TITLE
Fix handling of SAMP coord.pointAt.sky messages (fix #26)

### DIFF
--- a/website/js/wwtsamp.js
+++ b/website/js/wwtsamp.js
@@ -188,13 +188,29 @@ const wwtsamp = (function () {
   //       stored location
   function handlePointAtSky(senderId, message, isCall) {
     const params = message['samp.params'];
-    const ra = params['ra'];
-    const dec = params['dec'];
 
-    console.log('pointAt.sky sent'); console.log(typeof ra); console.log(typeof dec);
+    sampTrace(`SAMP coord.pointAt.sky sent ra=${params['ra']} dec=${params['dec']}`);
 
-    wwt.gotoRaDecZoom(ra, dec, wwt.get_fov(), false);
-    sampReport('Moving to α=' + ra + ' δ=' + dec);
+    // Use subtly-different error messages for the two cases.
+    //
+    const ra = Number(params['ra']);
+    const dec = Number(params['dec']);
+
+    sampTrace(`SAMP coord.pointAt.sky -> ra=${ra} dec=${dec}`);
+
+    // This includes ra/dec parameters being undefined
+    if (isNaN(ra) || isNaN(dec)) {
+      sampReport(`Unsupported coordinates for move:<br/>α=${params['ra']} δ=${params['dec']}`);
+      return;
+    }
+
+    if ((ra < 0) || (ra >= 360.0) || (dec < -90) || (dec > 90)) {
+      sampReport(`Invalid coordinates for move:<br/>α=${params['ra']} δ=${params['dec']}`);
+      return;
+    }
+
+    wwt.moveTo(ra, dec);
+    sampReport(`Moving to α=${ra} δ=${dec}`);
   }
 
   // Tell others we've moved.

--- a/website/wwt.js
+++ b/website/wwt.js
@@ -3368,6 +3368,19 @@ var wwt = (function () {
 
   }
 
+  // primarily for websamp coord.pointAt.sky handler
+  //
+  function moveTo(ra0, dec0) {
+    trace(`Moving display to ra=${ra0} dec=${dec0}`);
+
+    // simplest way to check input is to ensure it's a Number
+    const ra = Number(ra0);
+    const dec = Number(dec0);
+    if (isNaN(ra) || isNaN(dec)) { return; }
+    if ((ra < 0) || (ra >= 360) || (dec < -90) || (dec > 90)) { return; }
+    wwt.gotoRaDecZoom(ra, dec, wwt.get_fov(), false);
+  }
+
   function setPosition(ra, dec, label, fov) {
 
     // Could request the current FOV, but I think it makes
@@ -4205,6 +4218,7 @@ var wwt = (function () {
     getWWTControl: function () { return wwt; },
 
     setPosition: setPosition,
+    moveTo: moveTo,
 
     hideSources: hideSources,
     showSources: showSources,


### PR DESCRIPTION
The display should now move when told to by SAMP. Assuming the WWT/CSC page has registered with a Web-SAMP capable hub.