### PR TITLE
Fix bookmarking (fix #28)

### DIFF
--- a/website/wwt.js
+++ b/website/wwt.js
@@ -3029,7 +3029,11 @@ var wwt = (function () {
   // Pull out the ra/dec handling so that we don't stop parsing
   // other elements in the query if one of these fails.
   //
-  function handleQueryLocation(raStr, decStr, zoomStr) {
+  function handleQueryLocation(params) {
+    // zoom is only used if ra and dec are given, but is optional
+    const raStr = params.get('ra');
+    const decStr = params.get('dec');
+    const zoomStr = params.get('zoom');
     if ((raStr === null) || (decStr === null)) { return; }
 
     const ra = Number(raStr);
@@ -3102,11 +3106,7 @@ var wwt = (function () {
 
     trace(` -> polygon=${displayPolygonSelect} csc11=${displayCSC11} chs=${displayCHS} nearest-stacks=${displayNearestStacks} nearest-sources=${displayNearestSources}`);
 
-    // zoom is only used if ra and dec are given, but is optional
-    const raStr = params.get('ra');
-    const decStr = params.get('dec');
-    const zoomStr = params.get('zoom');
-    handleQueryLocation(raStr, decStr, zoomStr);
+    handleQueryLocation(params);
 
     // Match against the values in the select widget, to ensure it
     // is a valid setting.

--- a/website/wwt.js
+++ b/website/wwt.js
@@ -326,7 +326,17 @@ var wwt = (function () {
     }
     if (display === null) { return null; }
 
-    return `${window.location.href}?ra=${ra},dec=${dec},display=${display}`;
+    // Need to remove any existing search term
+    //
+    try {
+      const url = new URL(document.location);
+    } catch (e) {
+      console.log(`ERROR: unable to create a URL for the page`);
+      return null;
+    }
+
+    url.search = '';
+    return `${url.href}?ra=${ra}&dec=${dec}&zoom=${zoom}&display=${display}`;
   }
   
   function clipBookmark(event) {


### PR DESCRIPTION
 - Removes any existing query string before creating the bookmark
 - Uses "&" to separate the terms instead of ","
 - Adds in the zoom level