### PR TITLE
Work around Plotly refusing to create a plot.

### DIFF
--- a/website/js/wwtplots.js
+++ b/website/js/wwtplots.js
@@ -256,12 +256,24 @@ const wwtplots = (function () {
 	    nplots += 1;
 	}
 
+      // Have a problem with p4; may happen with other plots too
+      // but for now just handle the p4 failure case.
+      //
 	if (p4 !== null) {
-	    // Plotly.newPlot(plot4, p4.data, p4.opts, genOpts);
+	  // Plotly.newPlot(plot4, p4.data, p4.opts, genOpts);
+	  let p4okay = true;
+	  try {
 	    Plotly.react(plot4, p4.data, p4.opts, genOpts);
+	  } catch (e) {
+	    console.log(`DBG: plotly (p4) threw ${e}`);
+	    p4okay = false;
+	  }
+
+	  if (p4okay) {
 	    if (nplots === 0) { defaultPlot = 4; }
 	    plotShown[3] = true;
 	    nplots += 1;
+	  }
 	}
 
 	// Make sure display areas are reset; also need to toggle the


### PR DESCRIPTION
It is unclear to me why the ACIS/HRC histogram can't be created in the
problem case (?ra=118.26292&dec=-49.61583&zoom=0.8), but work around
this plot failing. I should try and work out what is causing Plotly such conniptions,
but it probably makes sense to add this for all the plot types.