### PR TITLE
Make samp optional (fix #27)

### DIFF
--- a/website/js/wwtsamp.js
+++ b/website/js/wwtsamp.js
@@ -37,11 +37,13 @@ const wwtsamp = (function () {
   //     extra information for tracking).
   //
   //
-  function openSAMP(report, trace) {
-    if (sampConnection !== null) { return; }
-
+  function onload(report, trace) {
     sampReport = report;
     sampTrace = trace;
+  }
+
+  function openSAMP() {
+    if (sampConnection !== null) { return; }
 
     // Could create this in global scope, but let's see if we can
     // initialize it the first time it is needed.
@@ -126,6 +128,11 @@ const wwtsamp = (function () {
     // operation).
     //
     // sampConnection = null;
+
+    // Ensure any elements that require SAMP are hidden
+    for (let el of document.querySelectorAll('.requires-samp')) {
+      el.style.display = 'none';
+    }
 
     sampTrace('Unregistered SAMP');
   }
@@ -330,7 +337,8 @@ const wwtsamp = (function () {
             'Stack evt3 for ' + stack);
   }
     
-  return { setup: openSAMP,
+  return { onload: onload,
+	   setup: openSAMP,
            teardown: closeSAMP,
 	   startPolling: startPolling,
 	   stopPolling: stopPolling,
@@ -344,7 +352,10 @@ const wwtsamp = (function () {
            sendStackEvt3: sendStackEvt3,
 
            // For debugging
-           getSAMPConnection: () => { return sampConnection; },
+           getSAMPConnection: () => sampConnection,
+
+	   hasConnected: () => sampConnection !== null,
+	   isRegistered: () => sampIsRegistered,
          };
 
 })();

--- a/website/wwt.js
+++ b/website/wwt.js
@@ -54,6 +54,7 @@ var wwt = (function () {
   const keyCrosshairs = 'wwt-crosshairs';
   const keyConstellations = 'wwt-constellations';
   const keyBoundaries = 'wwt-boundaries';
+  const keySAMP = 'wwt-samp';
   const keyMilkyWay = 'wwt-milkyway';
   const keyClipboardFormat = 'wwt-clipboardformat';
 
@@ -64,6 +65,7 @@ var wwt = (function () {
 		  keySave, keyLocation, keyFOV, keyForeground,
 		  keyCoordinateGrid,
 		  keyCrosshairs, keyConstellations, keyBoundaries,
+		  keySAMP,
 		  keyMilkyWay, keyClipboardFormat];
 
     keys.forEach(key => {
@@ -630,6 +632,20 @@ var wwt = (function () {
     saveState(keyBoundaries, flag);
   }
 
+  function setSAMP(flag) {
+    if (flag) {
+      if (wwtsamp.hasConnected()) {
+	wwtsamp.startPolling();
+      } else {
+	wwtsamp.setup();
+      }
+    } else {
+      wwtsamp.stopPolling();
+      wwtsamp.teardown();
+    }
+    saveState(keySAMP, flag);
+  }
+
   // How are the toggle items handled?
   //
   // Need to look into when the Milky Way is read in, since if it
@@ -659,6 +675,8 @@ var wwt = (function () {
      change: setConstellations, defval: true},
     {key: keyBoundaries, sel: '#toggleboundaries',
      change: setBoundaries, defval: false},
+    {key: keySAMP, sel: '#togglesamp',
+     change: setSAMP, defval: true},
     {key: null, sel: '#togglebanners',
      change: showBanners, defval: true},
     {key: null, sel: '#togglefullscreen',
@@ -2630,7 +2648,11 @@ var wwt = (function () {
       resetLocation();
       removeSetupBanner();
 
-      wwtsamp.setup(reportUpdateMessage, trace);
+      // Only start up SAMP if the state allows it.
+      const sampState = getState(keySAMP);
+      if ((sampState === null) || (sampState === 'true')) {
+	wwtsamp.setup();
+      }
 
       // setupShowHide('#preselected'); // width changes if show/hide
       setupShowHide('#settings');
@@ -3056,6 +3078,11 @@ var wwt = (function () {
     }
 
     trace('initialize');
+
+    // Pass in useful information to wwtsamp (even if later we turn
+    // off support for SAMP).
+    //
+    wwtsamp.onload(reportUpdateMessage, trace);
 
     toggleOptionalBehavior();
 

--- a/website/wwt.xml
+++ b/website/wwt.xml
@@ -784,6 +784,12 @@ main#content div.wrap {
 	    <li>Is the boundary of the current constellation (that is,
 	    the constellation which covers the aim point) shown (default
 	    is no)?</li>
+	    <li>
+	      Should the page connect to Virtual Observatory applications
+	      such as TOPCAT and SAOImageDS9 using the
+	      SAMP standard (turning this on causes the page to poll for
+	      a SAMP hub every 5 seconds)?
+	    </li>
 	    <li>What format is used when copying a location to
 	    the clipboard (default is decimal degrees)?</li>
 	  </list>
@@ -1047,6 +1053,14 @@ main#content div.wrap {
 	      <input id="toggleboundaries" name="toggleboundaries"
 		     type="checkbox"/>
 	      <label for="toggleboundaries">Show the boundary of the current constellation</label>
+	    </div>
+
+	    <div class="checkbox">
+	      <input id="togglesamp" name="togglesamp"
+		     type="checkbox" checked="true"/>
+	      <label for="togglesamp">
+		Connect to Virtual Observatory applications?
+	      </label>
 	    </div>
 
 	    <div>


### PR DESCRIPTION
The SAMP support can now be turned off in the settings (and it is saved to the page state, so this change will be remembered next time the page is loaded with the same browser). This is primarily to support users who don't want to use SAMP and want to avoid the page doing excess work (although the primary benefit is likely me, since it stops filling up the console log when no SAMP hub is present).