### PR TITLE
Position elements at click (fix #39)

### DIFF
--- a/website/wwt.css
+++ b/website/wwt.css
@@ -620,6 +620,10 @@ option:disabled {
   float: left;
 }
 
+/*
+ * left/top positions are over-ridden based on the mouse event,
+ * left in until confident the new scheme works well
+ */
 .tooltip {
   background: black;
   border: solid 1px white;  /* not 100% sure about this */

--- a/website/wwt.css
+++ b/website/wwt.css
@@ -635,6 +635,7 @@ option:disabled {
   position: absolute;
   text-align: center;
   top: 0.5em;
+  z-index: 150; /* larger than #wwtusercontrol */
 }
 
 #smallify-tooptip , #biggify-tooltip {
@@ -664,6 +665,11 @@ option:disabled {
 
 #targetFind-tooltip {
   top: 1.5em;
+}
+
+#coordinate-clip-tooltip , #bookmark-tooltip {
+  font-family: sans-serif; /* remove monospace font */
+  width: 15em;
 }
 
 #smallify {

--- a/website/wwt.js
+++ b/website/wwt.js
@@ -868,6 +868,56 @@ var wwt = (function () {
   const changeSource11Size = makeSizeUpdate(catalogProps.csc11);
   const changeXMMSourceSize = makeSizeUpdate(catalogProps.xmm);
 
+  // Position the element at the location given in event (clientX/Y).
+  // The default location is +5 in both X and Y, but if this takes the
+  // element off the screen then switch so that the bottom or right is
+  // positioned -5.
+  //
+  // If the box is too wide or tall then do not display and return
+  // false, otherwise return true.
+  //
+  // This is for elements that are positioned on the whole panel,
+  // not ones that are restricted to a sub-element (e.g. within a panel),
+  // and that have 'position: absolute' (not enforced here).
+  //
+  function positionAtClick(element, event) {
+    const host = getHost();
+    if (host === null) { return false; }
+
+    // const hostbbox = element.parentElement.getBoundingClientRect();
+    const hostbbox = host.getBoundingClientRect();
+    const elementbbox = element.getBoundingClientRect();
+
+    // const xmin = 0;
+    // const ymin = 0;
+    const xmax = hostbbox.width - elementbbox.width;
+    const ymax = hostbbox.height - elementbbox.height;
+
+    // buffer around the event (so that the element doesn't cover the
+    // click location).
+    //
+    const dx = 5;
+    const dy = 5;
+
+    let x = event.clientX;
+    let y = event.clientY;
+
+    if (x > (xmax - dx)) { x = x - elementbbox.width - dx; }
+    if (y > (ymax - dx)) { y = y - elementbbox.height - dy; }
+
+    // Can determine this before calculating x and y, but err on the
+    // side of caution by checking the value here.
+    //
+    if ((x <= 0) || (y <= 0)) {
+      trace('Unable to place element (too wide or high) so skipping');
+      return false;
+    }
+
+    element.style.left = `${x}px`;
+    element.style.top = `${y}px`;
+    return true;
+  }
+
   // From
   // https://hackernoon.com/copying-text-to-clipboard-with-javascript-df4d4988697f
   // Also comments from
@@ -938,39 +988,9 @@ var wwt = (function () {
     parent.appendChild(text);
 
     host.appendChild(parent);
-
-    // Position relative to event. The issue is that we have to
-    // worry about falling off the screen.
-    //
-    // Are these values available and reliable at this time?
-    //
-    // If the display is too narrow or tall then remove this
-    // element.
-    //
-    // Use getBoundingClientRect or offsetWidth/Height values?
-    //
-    const parentbbox = parent.getBoundingClientRect();
-    const hostbbox = parent.parentElement.getBoundingClientRect();
-
-    // const xmin = 0;
-    // const ymin = 0;
-    const xmax = hostbbox.width - parentbbox.width;
-    const ymax = hostbbox.height - parentbbox.height;
-
-    if ((xmax <= 0) || (ymax <= 0)) {
-      trace('Unable to place share box so skipping');
+    if (!positionAtClick(parent, event)) {
       host.removeChild(parent);
-      return;
     }
-
-    let x = event.clientX;
-    let y = event.clientY;
-
-    if (x > xmax) { x = xmax; }
-    if (y > ymax) { y = ymax; }
-
-    parent.style.left = `${x}px`;
-    parent.style.top = `${y}px`;
   }
 
   // This updates the stackAnnotations dict

--- a/website/wwt.js
+++ b/website/wwt.js
@@ -2883,10 +2883,20 @@ var wwt = (function () {
 
     tooltipTimers[name] = null;
 
-    el.addEventListener('mouseenter', () => {
+    // Should this be mouseover or mouseenter? If it is only ever
+    // used on img elements I'm not sure if it makes any real
+    // difference.
+    //
+    el.addEventListener('mouseenter', ev => {
       clearToolTipTimer(name);
+      // Delay the entrance so that if the user is just mousing over
+      // everything the tooltip doesn't just flash up and then
+      // disappear.
       const timer = setTimeout(() => {
         tt.style.display = 'inline';
+	if (!positionAtClick(tt, ev)) {
+	  tt.style.display = 'none';
+	}
         const timer2 = setTimeout(() => {
           tt.style.display = 'none';
         }, timeout * 1000);

--- a/website/wwt.js
+++ b/website/wwt.js
@@ -869,9 +869,9 @@ var wwt = (function () {
   const changeXMMSourceSize = makeSizeUpdate(catalogProps.xmm);
 
   // Position the element at the location given in event (clientX/Y).
-  // The default location is +5 in both X and Y, but if this takes the
+  // The default buffer is +5 in both X and Y, but if this takes the
   // element off the screen then switch so that the bottom or right is
-  // positioned -5.
+  // positioned -5. This can be changed with the third argument.
   //
   // If the box is too wide or tall then do not display and return
   // false, otherwise return true.
@@ -880,9 +880,18 @@ var wwt = (function () {
   // not ones that are restricted to a sub-element (e.g. within a panel),
   // and that have 'position: absolute' (not enforced here).
   //
-  function positionAtClick(element, event) {
+  function positionAtClick(element, event, buffer) {
     const host = getHost();
     if (host === null) { return false; }
+
+    if (typeof buffer !== 'undefined') {
+      if (buffer <= 0) {
+	console.log(`Internal error: buffer=${buffer}`);
+	return;
+      }
+    } else {
+      buffer = 5;
+    }
 
     // const hostbbox = element.parentElement.getBoundingClientRect();
     const hostbbox = host.getBoundingClientRect();
@@ -896,8 +905,8 @@ var wwt = (function () {
     // buffer around the event (so that the element doesn't cover the
     // click location).
     //
-    const dx = 5;
-    const dy = 5;
+    const dx = buffer;
+    const dy = buffer;
 
     let x = event.clientX;
     let y = event.clientY;
@@ -2894,7 +2903,8 @@ var wwt = (function () {
       // disappear.
       const timer = setTimeout(() => {
         tt.style.display = 'inline';
-	if (!positionAtClick(tt, ev)) {
+	// TODO: can we convert 1em to a pixel size?
+	if (!positionAtClick(tt, ev, 10)) {
 	  tt.style.display = 'none';
 	}
         const timer2 = setTimeout(() => {

--- a/website/wwt.xml
+++ b/website/wwt.xml
@@ -96,12 +96,6 @@ main#content div.wrap {
             <img id="bigify" alt="Show"
 		 class="usercontrol icon"
 		 src="wwtimg/fa/chevron-circle-up.svg"/>
-	    <div class="tooltip" id="smallify-tooltip">
-	      Hide the control panel.
-	    </div>
-	    <div class="tooltip" id="bigify-tooltip">
-	      Display the control panel.
-	    </div>
           </div>
 
 	  <div class="with-tooltip-static">
@@ -110,9 +104,6 @@ main#content div.wrap {
 		 alt="Register with a SAMP Hub"
 		 onclick="wwtsamp.register()"
 		 src="wwtimg/fa/broadcast-tower.svg"/>
-	    <div class="tooltip" id="register-samp-tooltip">
-	      Register the WWT display with a SAMP Hub.
-	    </div>
 	  </div>
 
 
@@ -121,52 +112,31 @@ main#content div.wrap {
 	  <div class="with-tooltip">
             <img id="zoomout" alt="Zoom Out"
 		 class="usercontrol icon" src="wwtimg/fa/minus-circle.svg"/>
-	    <div class="tooltip" id="zoomout-tooltip">
-	      Zoom out slightly.
-	    </div>
 	  </div>
 	  <div class="with-tooltip">
             <img id="zoomin" alt="Zoom In"
 		 class="usercontrol icon" src="wwtimg/fa/plus-circle.svg"/>
-	    <div class="tooltip" id="zoomin-tooltip">
-	      Zoom in slightly.
-	    </div>
 	  </div>
 	  <div class="with-tooltip">
             <img id="zoomn" alt="Zoom fully in"
 		 class="usercontrol icon"
 		 src="wwtimg/fa/compress-arrows-alt.svg"/>
-	    <div class="tooltip" id="zoomn-tooltip">
-	      Zoom the display to a level appropriate for
-	      individual CSC sources.
-	    </div>
 	  </div>
 	  <div class="with-tooltip">
             <img id="zoom0" alt="Zoom fully out"
 		 class="usercontrol icon"
 		 src="wwtimg/fa/expand-arrows-alt.svg"/>
-	    <div class="tooltip" id="zoom0-tooltip">
-	      Zoom the display out as far as it will go!
-	    </div>
 	  </div>
 	  <div class="with-tooltip">
             <img id="plot-properties"
 		 alt="Plot source properties"
 		 class="usercontrol icon"
 		 src="wwtimg/fa/chart-area.svg"/>
-	    <div class="tooltip" id="plot-properties-tooltip">
-	      Display summary plots of the properties of the
-	      shown CSC sources.
-	    </div>
 	  </div>
 	  <div class="with-tooltip">
             <img id="export-samp" alt="Send via SAMP"
 		 class="usercontrol icon"
 		 src="wwtimg/fa/share.svg"/>
-	    <div class="tooltip" id="export-samp-tooltip">
-	      Send summary properties of shown CSC sources
-	      to virtual-observatory applications.
-	    </div>
 	  </div>
 	</div>
 
@@ -187,24 +157,16 @@ main#content div.wrap {
 				       id="dec_d">&nbsp;</output>°<output class="pos"
 				       id="dec_m">&nbsp;</output>'<output class="pos"
 				       id="dec_s">&nbsp;</output>"
-	    <img src="wwtimg/fa/cut.svg" id="coordinate-clip"
-		 alt="Scissors (cut to clipboard)"
-		 class="icon"/>
+	      <img src="wwtimg/fa/cut.svg" id="coordinate-clip"
+		   alt="Scissors (cut to clipboard)"
+		   class="icon"/>
 	    </p>
-	    <div class="tooltip" id="coordinate-clip-tooltip">
-	      Copy RA and Dec to the clipboard, as decimal degrees.
-	    </div>
 	    <p class="centered">
 	      FOV: <span id="fov"></span>
 	      <img src="wwtimg/fa/bookmark.svg" id="bookmark"
 		   alt="Bookmark this location (copy URL to clipboard)"
 		   class="icon end-of-line"/>
 	    </p>
-	    <div class="tooltip" id="bookmark-tooltip">
-	      Create a URL for the current display (location,
-	      zoom level, and selected wavelength for the background
-	      data) and copy it to the clipboard.
-	    </div>
 	  </div>
 
 	</div>
@@ -224,26 +186,6 @@ main#content div.wrap {
 		   alt="Magnifying glass"
 		   class="icon"/>
 	    </button>
-	    <div class="tooltip" id="targetName-tooltip">
-	      A name can be given (e.g.
-	      <span class="term">Orion cluster</span>
-	      or
-	      <span class="term">M31</span>), which is passed to the
-	      LookUp service, or a location can be given using a comma
-	      to separate the Right Ascension from the Declination.
-	      In this latter case
-	      a limited variety of coordinate formats are supported,
-	      including 
-	      <span class="term">205.842, -14.8367</span>;
-	      <span class="term">13 43 22, -14 50 12</span>;
-	      <span class="term">13:43:22, -14:50:12</span>;
-	      <span class="term">13h 43m 22s, -14d 50m 12s</span>;
-	      and
-	      <span class="term">13h 43m 22s, -14d 50' 12"</span>.
-	    </div>
-	    <div class="tooltip" id="targetFind-tooltip">
-	      Find and move to the given location.
-	    </div>
           </div>
 
 	  <div class="centered">
@@ -403,6 +345,66 @@ main#content div.wrap {
 	  </div>
 	</div> <!-- id=wwtuserbuttons -->
       </div> <!-- id=wwtusercontrol -->
+
+      <!-- tooltips -->
+      <div class="tooltip" id="smallify-tooltip">
+	Hide the control panel.
+      </div>
+      <div class="tooltip" id="bigify-tooltip">
+	Display the control panel.
+      </div>
+      <div class="tooltip" id="register-samp-tooltip">
+	Register the WWT display with a SAMP Hub.
+      </div>
+      <div class="tooltip" id="zoomout-tooltip">
+	Zoom out slightly.
+      </div>
+      <div class="tooltip" id="zoomin-tooltip">
+	Zoom in slightly.
+      </div>
+      <div class="tooltip" id="zoomn-tooltip">
+	Zoom the display to a level appropriate for
+	individual CSC sources.
+      </div>
+      <div class="tooltip" id="zoom0-tooltip">
+	Zoom the display out as far as it will go!
+      </div>
+      <div class="tooltip" id="plot-properties-tooltip">
+	Display summary plots of the properties of the
+	shown CSC sources.
+      </div>
+      <div class="tooltip" id="export-samp-tooltip">
+	Send summary properties of shown CSC sources
+	to virtual-observatory applications.
+      </div>
+      <div class="tooltip" id="coordinate-clip-tooltip">
+	Copy RA and Dec to the clipboard, as decimal degrees.
+      </div>
+      <div class="tooltip" id="bookmark-tooltip">
+	Create a URL for the current display (location,
+	zoom level, and selected wavelength for the background
+	data) and copy it to the clipboard.
+      </div>
+      <div class="tooltip" id="targetName-tooltip">
+	A name can be given (e.g.
+	<span class="term">Orion cluster</span>
+	or
+	<span class="term">M31</span>), which is passed to the
+	LookUp service, or a location can be given using a comma
+	to separate the Right Ascension from the Declination.
+	In this latter case
+	a limited variety of coordinate formats are supported,
+	including
+	<span class="term">205.842, -14.8367</span>;
+	<span class="term">13 43 22, -14 50 12</span>;
+	<span class="term">13:43:22, -14:50:12</span>;
+	<span class="term">13h 43m 22s, -14d 50m 12s</span>;
+	and
+	<span class="term">13h 43m 22s, -14d 50' 12"</span>.
+      </div>
+      <div class="tooltip" id="targetFind-tooltip">
+	Find and move to the given location.
+      </div>
 
       <!-- Inform the user when the stack status has been updated -->
       <div id="stackUpdateStatus"></div>


### PR DESCRIPTION
Position tooltip and clipboard "panels" close to the event that triggered their appearance (i.e. the mouse clock).