### PR TITLE
Prepare for AAS 2019 Summer meeting

### DIFF
--- a/website/js/wwtprops.js
+++ b/website/js/wwtprops.js
@@ -1306,7 +1306,9 @@ const wwtprops = (function () {
 		  {value: 'photometry', label: 'Photometric'},
 		  {value: 'variability', label: 'Variability'}];
     opts.forEach(opt => {
-      addOption(adqlList, opt.value, opt.label);
+      // Add 'Master Source' prefix to match CSCView but will it
+      // use up too-much space on the screen?
+      addOption(adqlList, opt.value, `Master Source ${opt.label}`);
     });
 
     const lbl1 = document.createElement('label');

--- a/website/js/wwtprops.js
+++ b/website/js/wwtprops.js
@@ -1187,7 +1187,6 @@ const wwtprops = (function () {
     //
     // Also decide the "new" default selection here (although it
     // may not be used), and store the value rather than the label.
-    // The use of strings here is not ideal.
     //
     const newOptions = [];
     const allOption = makeOption(wwtsamp.TARGET_ALL, 'All clients');
@@ -1217,7 +1216,7 @@ const wwtprops = (function () {
     let i;
     if (oldOptions.length === newOptions.length + startClear) {
       let flag = true;
-      for (i = startClear; flag && (i < newOptions.length); i++) {
+      for (i = 0; flag && (i < newOptions.length); i++) {
 	const oldO = oldOptions[i + startClear];
 	const newO = newOptions[i];
 	const same = ((oldO.value === newO.value) &&

--- a/website/wwt.js
+++ b/website/wwt.js
@@ -35,9 +35,11 @@ var wwt = (function () {
   //     - show nearest stacks
   //     - show nearest sources
   //
-  // We flip these all to true if run on the test server.
+  // We flip these all to true if run on the test server (TEMPORARILY
+  // DISABLED).
+  //
   let displayCHS = false;
-  let displayCSC11 = false;
+  let displayCSC11 = true;
   let displayPolygonSelect = false;
   let displayNearestStacks = false;
   let displayNearestSources = false;
@@ -3121,6 +3123,7 @@ var wwt = (function () {
 
     // Hard-code behavior for the test server
     //
+    /** TEMPORARILY DISABLED
     const origin = loc.origin;
     if (typeof origin !== 'undefined' && origin.indexOf('cxc-dmz-prev') > 0) {
       displayPolygonSelect = true;
@@ -3129,6 +3132,7 @@ var wwt = (function () {
       displayNearestStacks = true;
       displayNearestSources = true;
     }
+    **/
 
     // Only ever support turning on an option, not off.
     displayPolygonSelect = displayPolygonSelect || params.has('polygon');


### PR DESCRIPTION
Add 'Master source ' label to the ADQL query types for the source properties, to match CSCView. Suggested by Raffaele D'Abrusco.

Hopefully fix the SAMP client list refresh, so that it recognizes when a single client is registered and changes its name field. This could occasionally be seen in the stack window when only SAOImageDS9 was available.

Turn off the optional features for the preview site, to make testing easier. They can still be explicitly enabled.

Re-work the script used to extract the stak evt3 file names from the CSCCLI to also support the sensitivity images (b or w band only)