### PR TITLE
Support exporting sensitivity image for each stack

### DIFF
--- a/code/get_stack_names.py
+++ b/code/get_stack_names.py
@@ -3,7 +3,7 @@
 """
 Usage:
 
-  python get_stack_names.py infile [stkevt3|sensity]
+  python get_stack_names.py infile <option>
 
 Aim:
 
@@ -12,7 +12,13 @@ is, the file name needed to query the csccli to get the data product.
 
 infile must have a stack column
 
-The options are stkevt3 or sensity - which means b or w band.
+The option is for b or w band only (when an image) and must be one of:
+
+  stkevt3
+  stkecorrimg
+  stkbkgimg
+  stkexpmap
+  sensity
 
 """
 
@@ -26,7 +32,7 @@ import json
 def get_url(stack, proptype):
 
     url = 'http://cda.harvard.edu/csccli/browse?version=cur&packageset={}%2F{}'.format(stack, proptype)
-    if proptype == 'sensity':
+    if proptype != 'stkevt3':
         url += '%2F'
         if stack.startswith('hrc'):
             url += 'w'
@@ -63,21 +69,24 @@ def report_filename(stack, proptype):
     sys.stdout.flush()
 
 
+options = ['stkevt3', 'stkecorrimg', 'stkbkgimg', 'stkexpmap', 'sensity']
+
+
 def usage():
     sys.stderr.write("Usage: {} ".format(sys.argv[0]))
-    sys.stderr.write("stackfile [stkevt3|sensity]\n")
+    sys.stderr.write("stackfile <option>\n")
+    sys.stderr.write("\n<option> is one of:\n")
+    sys.stderr.write("  {}\n".format(" ".join(options)))
     sys.exit(1)
 
 
 if __name__ == "__main__":
 
     nargs = len(sys.argv)
-    if nargs < 2 or nargs > 3:
+    if nargs != 3:
         usage()
 
-    if nargs == 2:
-        proptype = 'stkevt3'
-    elif sys.argv[2] in ['stkevt3', 'sensity']:
+    if sys.argv[2] in options:
         proptype = sys.argv[2]
     else:
         usage()

--- a/code/parse_stack_names.py
+++ b/code/parse_stack_names.py
@@ -3,7 +3,7 @@
 """
 Usage:
 
-  ./parse_stack_names.py stkevt3|sensity output-of-get_stack_names.py
+  ./parse_stack_names.py <option> output-of-get_stack_names.py
 
 Aim:
 
@@ -11,6 +11,17 @@ Construct a JSON file mapping from stack id to version number. The
 assumption is that one version number is going to dominate the
 counts, so we only have to give versions for stacks that don't
 meet this version.
+
+The option must be one of (although its value isn't actually checked):
+
+  stkevt3
+  stkecorrimg
+  stkbkgimg
+  stkexpmap
+  sensity
+
+and assumes there is only a single band for each stack (for the case
+where there are multiple bands for a file type).
 
 """
 
@@ -67,7 +78,7 @@ def convert(filetype, infile):
     sys.stderr.write("Version breakdown\n")
     for v, c in vs:
         sys.stderr.write("  version= {:3d}  count= {}\n".format(v, c))
-    
+
     out['default_version'] = default_version
     out['ndefault_version'] = ndef
     delete = []
@@ -82,9 +93,14 @@ def convert(filetype, infile):
     print(json.dumps(out))
 
 
-def usage(progname):
-    sys.stderr.write("Usage: {} ".format(progname))
-    sys.stderr.write("stkevt3|sensity infile\n")
+options = ['stkevt3', 'stkecorrimg', 'stkbkgimg', 'stkexpmap', 'sensity']
+
+
+def usage():
+    sys.stderr.write("Usage: {} ".format(sys.argv[0]))
+    sys.stderr.write("<option> infile\n")
+    sys.stderr.write("\n<option> is one of:\n")
+    sys.stderr.write("  {}\n".format(" ".join(options)))
     sys.exit(1)
 
 
@@ -92,7 +108,7 @@ if __name__ == "__main__":
 
     nargs = len(sys.argv)
     if nargs != 3:
-        usage(sys.argv[0])
+        usage()
 
     filetype = sys.argv[1]
     infile = sys.argv[2]

--- a/website/js/wwtprops.js
+++ b/website/js/wwtprops.js
@@ -453,6 +453,10 @@ const wwtprops = (function () {
     const band = stack.stackid.startsWith('acis') ? 'broad' : 'wide';
 
     const opts = [{value: 'stkevt3', label: 'Stack event file'},
+		  {value: 'stkecorrimg',
+		   label: `Stack ${band}-band exposure-corrected image`},
+		  {value: 'stkbkgimg',
+		   label: `Stack ${band}-band background image`},
 		  {value: 'sensity',
 		   label: `Stack ${band}-band sensitivity image`}];
 
@@ -496,17 +500,24 @@ const wwtprops = (function () {
       els.button.addEventListener('click', (event) => {
 	console.log(`Chosen option: ${selected.choice}`);
 	console.log(`Chosen target: ${selected.target}`);
+	let send = null;
 	if (selected.choice === 'stkevt3') {
-	  wwtsamp.sendStackEvt3(event, stack.stackid,
-				versionTable[selected.choice],
-				selected.target);
+	  send = wwtsamp.sendStackEvt3;
+	} else if (selected.choice === 'stkecorrimg') {
+	  send = wwtsamp.sendStackEcorrImg;
+	} else if (selected.choice === 'stkbkgimg') {
+	  send = wwtsamp.sendStackBkgImg;
 	} else if (selected.choice === 'sensity') {
-	  wwtsamp.sendStackSensity(event, stack.stackid,
-				   versionTable[selected.choice],
-				   selected.target);
+	  send = wwtsamp.sendStackSensity;
+	}
+
+	if (send !== null) {
+	  send(event, stack.stackid, versionTable[selected.choice],
+	       selected.target);
 	} else {
 	  console.log(`INTERNAL ERROR: unsupported option ${selected.choice}`);
 	}
+
       }, false);
     }
 

--- a/website/js/wwtprops.js
+++ b/website/js/wwtprops.js
@@ -438,23 +438,24 @@ const wwtprops = (function () {
 
   // Add in the SAMP export button for the stack info panel.
   //
-  // versionTable is expected to contain stkevt3 and sensity fields,
-  // which are either numbers or null.
+  // versionTable is expected to contain fielts which are either
+  // numbers or null, and refer to the filetypes available to
+  // download (and must match the value field of the opts array
+  // below).
   //
   function addSendStackEvtFile(active, parent, stack, versionTable) {
     const clientListId = 'export-clientlist-stkevt';
     const mtype = 'image.load.fits';
 
-    // What is being exported? This is expect ro be a "scalar" or
-    // multiple items, but the way the data is currently aligned it
-    // is either going to be null or everything, but we retain support
-    // for only a subset being available.
+    // What is being exported?
     //
     const band = stack.stackid.startsWith('acis') ? 'broad' : 'wide';
 
     const opts = [{value: 'stkevt3', label: 'Stack event file'},
 		  {value: 'stkecorrimg',
 		   label: `Stack ${band}-band exposure-corrected image`},
+		  {value: 'stkexpmap',
+		   label: `Stack ${band}-band exposure map`},
 		  {value: 'stkbkgimg',
 		   label: `Stack ${band}-band background image`},
 		  {value: 'sensity',
@@ -505,6 +506,8 @@ const wwtprops = (function () {
 	  send = wwtsamp.sendStackEvt3;
 	} else if (selected.choice === 'stkecorrimg') {
 	  send = wwtsamp.sendStackEcorrImg;
+	} else if (selected.choice === 'stkexpmap') {
+	  send = wwtsamp.sendStackExpMap;
 	} else if (selected.choice === 'stkbkgimg') {
 	  send = wwtsamp.sendStackBkgImg;
 	} else if (selected.choice === 'sensity') {

--- a/website/js/wwtsamp.js
+++ b/website/js/wwtsamp.js
@@ -342,8 +342,13 @@ const wwtsamp = (function () {
 
       msg += ` responded to the ${mtype} request.`;
 
+      // This used to say 'stack event file' but we now support other
+      // file types.
+      //
+      // TODO: should we just avoid this warning?
+      //
       if ((n > 0) && (mtype === 'image.load.fits')) {
-        msg += '\nWarning: downloading the stack event file can take a long time!';
+        msg += '\nWarning: downloading the stack data can take a long time!';
       }
 
       sampReport(msg);

--- a/website/js/wwtsamp.js
+++ b/website/js/wwtsamp.js
@@ -583,6 +583,21 @@ const wwtsamp = (function () {
 		  'stkecorrimg', stack, stackver, `${band}_img3`);
   }
 
+  // Send the exposure map: note that
+  // we pick the b or w band depending on the stack id.
+  //
+  function sendStackExpMap(event, stack, stackver, target) {
+    if ((typeof target === 'undefined') || (target === '')) {
+      console.log('Internal error: sendStackExpMap sent empty target');
+      return;
+    }
+
+    const band = stack.startsWith('acis') ? 'b' : 'w';
+    sendStackFile(event, target,
+		  `${band}-band exposure map`,
+		  'stkexpmap', stack, stackver, `${band}_exp3`);
+  }
+
   // Send the background image: note that
   // we pick the b or w band depending on the stack id.
   //
@@ -659,6 +674,7 @@ const wwtsamp = (function () {
            sendSourcePropertiesName: sendSourcePropertiesName,
            sendStackEvt3: sendStackEvt3,
 	   sendStackEcorrImg: sendStackEcorrImg,
+	   sendStackExpMap: sendStackExpMap,
 	   sendStackBkgImg: sendStackBkgImg,
 	   sendStackSensity: sendStackSensity,
 

--- a/website/js/wwtsamp.js
+++ b/website/js/wwtsamp.js
@@ -547,7 +547,7 @@ const wwtsamp = (function () {
       return;
     }
 
-    sampTrace(`SAMP: stack=${stack} ver=${stackver} target=${target}`);
+    sampTrace(`SAMP: stkevt3 stack=${stack} ver=${stackver} target=${target}`);
 
     // simple for now
     let verstr;
@@ -561,6 +561,34 @@ const wwtsamp = (function () {
     console.log(`--> sending image.load.fits for ${url}`);
     sendURL(event, target, 'image.load.fits', url,
             `Stack evt3 for ${stack}`);
+  }
+
+  // Send the sensitivity image: note that we pick the b or w band
+  // depending on the stack id.
+  //
+  function sendStackSensity(event, stack, stackver, target) {
+    if ((typeof target === 'undefined') || (target === '')) {
+      console.log('Internal error: sendStackSensity sent empty target');
+      return;
+    }
+
+    sampTrace(`SAMP: sensity stack=${stack} ver=${stackver} target=${target}`);
+
+    // simple for now
+    let verstr;
+    if (stackver < 10)       { verstr = '00' + stackver.toString(); }
+    else if (stackver < 100) { verstr = '0' + stackver.toString(); }
+    else                     { verstr = stackver.toString(); }
+
+    const band = stack.startsWith('acis') ? 'b' : 'w';
+
+    const url = 'http://cda.harvard.edu/csccli/retrieveFile?' +
+	  `version=cur&filetype=sensity&filename=${stack}N${verstr}_` +
+	  `${band}_sens3.fits`;
+
+    console.log(`--> sending image.load.fits for ${url}`);
+    sendURL(event, target, 'image.load.fits', url,
+            `Stack ${band}-band sensitivity image for ${stack}`);
   }
 
   // Return information on any SAMP clients that respond to the
@@ -608,6 +636,7 @@ const wwtsamp = (function () {
            sendSourcePropertiesNear: sendSourcePropertiesNear,
            sendSourcePropertiesName: sendSourcePropertiesName,
            sendStackEvt3: sendStackEvt3,
+	   sendStackSensity: sendStackSensity,
 
            // For debugging
            getSAMPConnection: () => sampConnection,

--- a/website/js/wwtsamp.js
+++ b/website/js/wwtsamp.js
@@ -541,13 +541,10 @@ const wwtsamp = (function () {
             'CSC 2.0 master-source properties (single source)');
   }
 
-  function sendStackEvt3(event, stack, stackver, target) {
-    if ((typeof target === 'undefined') || (target === '')) {
-      console.log('Internal error: sendStackEvt3 sent empty target');
-      return;
-    }
-
-    sampTrace(`SAMP: stkevt3 stack=${stack} ver=${stackver} target=${target}`);
+  // Send the stack file (e.g. event file or sensitivity image).
+  //
+  function sendStackFile(event, target, label, filetype, stack, stackver, suffix) {
+    sampTrace(`SAMP: ${filetype} stack=${stack} ver=${stackver} suffix=${suffix} target=${target}`);
 
     // simple for now
     let verstr;
@@ -556,11 +553,19 @@ const wwtsamp = (function () {
     else                     { verstr = stackver.toString(); }
 
     const url = 'http://cda.harvard.edu/csccli/retrieveFile?' +
-      `version=cur&filetype=stkevt3&filename=${stack}N${verstr}_evt3.fits`;
+      `version=cur&filetype=${filetype}&filename=${stack}N${verstr}_${suffix}.fits`;
 
     console.log(`--> sending image.load.fits for ${url}`);
     sendURL(event, target, 'image.load.fits', url,
-            `Stack evt3 for ${stack}`);
+            `Stack ${label} for ${stack}`);
+  }
+
+  function sendStackEvt3(event, stack, stackver, target) {
+    if ((typeof target === 'undefined') || (target === '')) {
+      console.log('Internal error: sendStackEvt3 sent empty target');
+      return;
+    }
+    sendStackFile(event, target, 'evt3', 'stkevt3', stack, stackver, 'evt3');
   }
 
   // Send the sensitivity image: note that we pick the b or w band
@@ -572,23 +577,10 @@ const wwtsamp = (function () {
       return;
     }
 
-    sampTrace(`SAMP: sensity stack=${stack} ver=${stackver} target=${target}`);
-
-    // simple for now
-    let verstr;
-    if (stackver < 10)       { verstr = '00' + stackver.toString(); }
-    else if (stackver < 100) { verstr = '0' + stackver.toString(); }
-    else                     { verstr = stackver.toString(); }
-
     const band = stack.startsWith('acis') ? 'b' : 'w';
-
-    const url = 'http://cda.harvard.edu/csccli/retrieveFile?' +
-	  `version=cur&filetype=sensity&filename=${stack}N${verstr}_` +
-	  `${band}_sens3.fits`;
-
-    console.log(`--> sending image.load.fits for ${url}`);
-    sendURL(event, target, 'image.load.fits', url,
-            `Stack ${band}-band sensitivity image for ${stack}`);
+    sendStackFile(event, target,
+		  `${band}-band sensitivity image`,
+		  'sensity', stack, stackver, `${band}_sens3`);
   }
 
   // Return information on any SAMP clients that respond to the

--- a/website/js/wwtsamp.js
+++ b/website/js/wwtsamp.js
@@ -568,6 +568,36 @@ const wwtsamp = (function () {
     sendStackFile(event, target, 'evt3', 'stkevt3', stack, stackver, 'evt3');
   }
 
+  // Send the exposure-corrected, background subtracted, image: note that
+  // we pick the b or w band depending on the stack id.
+  //
+  function sendStackEcorrImg(event, stack, stackver, target) {
+    if ((typeof target === 'undefined') || (target === '')) {
+      console.log('Internal error: sendStackEcorrImg sent empty target');
+      return;
+    }
+
+    const band = stack.startsWith('acis') ? 'b' : 'w';
+    sendStackFile(event, target,
+		  `${band}-band exposure-corrected background-subtracted image`,
+		  'stkecorrimg', stack, stackver, `${band}_img3`);
+  }
+
+  // Send the background image: note that
+  // we pick the b or w band depending on the stack id.
+  //
+  function sendStackBkgImg(event, stack, stackver, target) {
+    if ((typeof target === 'undefined') || (target === '')) {
+      console.log('Internal error: sendStackBkgImg sent empty target');
+      return;
+    }
+
+    const band = stack.startsWith('acis') ? 'b' : 'w';
+    sendStackFile(event, target,
+		  `${band}-band background image`,
+		  'stkbkgimg', stack, stackver, `${band}_bkgimg3`);
+  }
+
   // Send the sensitivity image: note that we pick the b or w band
   // depending on the stack id.
   //
@@ -628,6 +658,8 @@ const wwtsamp = (function () {
            sendSourcePropertiesNear: sendSourcePropertiesNear,
            sendSourcePropertiesName: sendSourcePropertiesName,
            sendStackEvt3: sendStackEvt3,
+	   sendStackEcorrImg: sendStackEcorrImg,
+	   sendStackBkgImg: sendStackBkgImg,
 	   sendStackSensity: sendStackSensity,
 
            // For debugging

--- a/website/wwt.js
+++ b/website/wwt.js
@@ -1356,8 +1356,14 @@ var wwt = (function () {
   // version number of the stack event file/sensitivity map
   // available in the archive.
   //
+  // The properties of this table define what data is loaded
+  // and displayed to the user (if available). So to just stick
+  // to the event file remove all but the stkevt3 setting.
+  //
   const stackVersionTable = {stkevt3: null, sensity: null,
-			     stkecorrimg: null, stkbkgimg: null};
+			     stkecorrimg: null,
+			     stkexpmap: null,
+			     stkbkgimg: null};
 
   // Create the function to show the catalog.
   //   properties is the catalogProps.catalog field
@@ -2285,12 +2291,11 @@ var wwt = (function () {
     // What version info do we have (aka can we export the data products
     // via SAMP) for this stack?
     //
-    const versionInfo =
-      {stkevt3: getVersion(stackVersionTable.stkevt3, stack0),
-       stkecorrimg: getVersion(stackVersionTable.stkecorrimg, stack0),
-       stkbkgimg: getVersion(stackVersionTable.stkbkgimg, stack0),
-       sensity: getVersion(stackVersionTable.sensity, stack0)
-      };
+    const versionInfo = {};
+    Object.keys(stackVersionTable).forEach(n => {
+      if (stackVersionTable[n] === null) { return; }
+      versionInfo[n] = getVersion(stackVersionTable[n], stack0);
+    });
     wwtprops.addStackInfo(stack0, versionInfo);
 
     if (seps.length === 0) { return; }
@@ -2707,6 +2712,9 @@ var wwt = (function () {
       // We create and execute the download function here.
       //
       Object.keys(stackVersionTable).forEach(n => {
+	if (stackVersionTable[n] !== null) {
+	  console.log(`INTERNAL ERROR: expected stackVersionTable.${n} to be null`);
+	}
 	const f = makeDownloadData(`wwtdata/version.${n}.json`,
 				   null, null,
 				   (d) => { stackVersionTable[n] = d; });

--- a/website/wwt.js
+++ b/website/wwt.js
@@ -1353,12 +1353,17 @@ var wwt = (function () {
 					   processXMMData);
 
   // Load in (asynchronously) the mapping between stack name and the
-  // version number of the stack event file available in the archive.
+  // version number of the stack event file/sensitivity map
+  // available in the archive.
   //
   var stackEventVersions = null;
+  var stackSensityVersions = null;
   const loadStackEventVersions = makeDownloadData('wwtdata/version.stkevt3.json',
 						  null, null,
 						  (d) => { stackEventVersions = d; });
+  const loadStackSensityVersions = makeDownloadData('wwtdata/version.sensity.json',
+						  null, null,
+						  (d) => { stackSensityVersions = d; });
 
   // Create the function to show the catalog.
   //   properties is the catalogProps.catalog field
@@ -2254,7 +2259,7 @@ var wwt = (function () {
     const fovs = stackAnnotations[stack0.stackid];
     fovs.forEach(fov => nearestFovs.push(changeFov(fov, true, 'cyan', 4)));
 
-    wwtprops.addStackInfo(stack0, stackEventVersions);
+    wwtprops.addStackInfo(stack0, stackEventVersions, stackSensityVersions);
 
     if (seps.length === 0) { return; }
 
@@ -2671,6 +2676,7 @@ var wwt = (function () {
       // sent via Web-SAMP, but leave in for now.
       //
       loadStackEventVersions();
+      loadStackSensityVersions();
       downloadEnsData();
 
       // TODO: should this only be changed once the ready function has

--- a/website/wwt.js
+++ b/website/wwt.js
@@ -1356,7 +1356,8 @@ var wwt = (function () {
   // version number of the stack event file/sensitivity map
   // available in the archive.
   //
-  const stackVersionTable = {stkevt3: null, sensity: null};
+  const stackVersionTable = {stkevt3: null, sensity: null,
+			     stkecorrimg: null, stkbkgimg: null};
 
   // Create the function to show the catalog.
   //   properties is the catalogProps.catalog field
@@ -2284,8 +2285,12 @@ var wwt = (function () {
     // What version info do we have (aka can we export the data products
     // via SAMP) for this stack?
     //
-    const versionInfo = {stkevt3: getVersion(stackVersionTable.stkevt3, stack0),
-			 sensity: getVersion(stackVersionTable.sensity, stack0)};
+    const versionInfo =
+      {stkevt3: getVersion(stackVersionTable.stkevt3, stack0),
+       stkecorrimg: getVersion(stackVersionTable.stkecorrimg, stack0),
+       stkbkgimg: getVersion(stackVersionTable.stkbkgimg, stack0),
+       sensity: getVersion(stackVersionTable.sensity, stack0)
+      };
     wwtprops.addStackInfo(stack0, versionInfo);
 
     if (seps.length === 0) { return; }
@@ -2701,7 +2706,7 @@ var wwt = (function () {
 
       // We create and execute the download function here.
       //
-      ['stkevt3', 'sensity'].forEach(n => {
+      Object.keys(stackVersionTable).forEach(n => {
 	const f = makeDownloadData(`wwtdata/version.${n}.json`,
 				   null, null,
 				   (d) => { stackVersionTable[n] = d; });

--- a/website/wwt.xml
+++ b/website/wwt.xml
@@ -769,10 +769,13 @@ main#content div.wrap {
 
 	  <p>
 	    The <span class='example-button'>Export ...</span>
-	    button lets you send the stack event file to a
+	    button lets you send the stack event file or
+	    sensitivity image to a
 	    Virtual-Observatory application if a SAMP hub
 	    is running on your machine and SAOImageDS9 is
-	    connected to it. If there is no SAMP hub then
+	    connected to it (or any other client that responds
+	    to the SAMP <span class="term">image.load.fits</span> message type).
+	    If there is no SAMP hub then
 	    the URL of the stack event file can be copied to
 	    the clipboard.
 	  </p>


### PR DESCRIPTION
This involves adding a choice to the SAMP export section of the 'Nearest Stack' panel,  allowing the user to export: stack event file, exposure-corrected and background-subtracted image, exposure map, background image, sensitivity image (where the images are either broad or wide band, depending on the stack). The choice depends on what is available (and can also be easily toggled from the code to allow this to be used on the live site but with only the stack-event file supported (or some other choice).

This addresses #51 (although there's still the decision on what should be exported, the labelling, and whether any warning on file size is needed).