### PR TITLE
Ignore keypress when in targetName

### DIFF
--- a/website/wwt.js
+++ b/website/wwt.js
@@ -861,6 +861,14 @@ var wwt = (function () {
             return;
         }
 
+        // Ensure we don't trigger on keyboard events to the name search.
+        // It would be nice if we had a better way to check this.
+        //
+        if (event.target.id === "targetName") {
+	    trace(`.. skipping keyboard event ${event.key} as in targetName`);
+	    return;
+        }
+
 	if (event.key in keyboard_toggles) {
 	    toggleBlockElement(keyboard_toggles[event.key]);
 	    return;


### PR DESCRIPTION
It would be nicer to do this more declaratively, but this
is the easiest fix I can come up with.

Are there any other places we would need to do this?